### PR TITLE
feat: hover interaction on tree + map via d3gl 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fontsource/open-sans": "^5.2.7",
         "@fontsource/philosopher": "^5.2.8",
         "@mapequation/c3": "^1.1.1",
-        "@mapequation/d3gl": "^0.4.1",
+        "@mapequation/d3gl": "^0.5.0",
         "@mapequation/infomap": "2.12.0",
         "@turf/boolean-intersects": "^7.3.5",
         "@turf/turf": "^7.3.5",
@@ -856,9 +856,9 @@
       }
     },
     "node_modules/@mapequation/d3gl": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@mapequation/d3gl/-/d3gl-0.4.1.tgz",
-      "integrity": "sha512-4ABlCc2IMv0omU5mr/pMCSCd8QIbxDmAEcGOZ7UOLVYeQaFkGI0EmTff5IC6kaa1p7NxNBr+Zz98l6Tl3ff9jw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@mapequation/d3gl/-/d3gl-0.5.0.tgz",
+      "integrity": "sha512-dpuhZMxWIlHhaNBQSryIEdELK8ja1yn5uqGwQJdxkXAE1WBOJFBP060d12j+egfR2UY5R4C7mXixWuzIk/ZZMA==",
       "license": "MIT",
       "dependencies": {
         "@luma.gl/core": "^9.3.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@fontsource/open-sans": "^5.2.7",
     "@fontsource/philosopher": "^5.2.8",
     "@mapequation/c3": "^1.1.1",
-    "@mapequation/d3gl": "^0.4.1",
+    "@mapequation/d3gl": "^0.5.0",
     "@mapequation/infomap": "2.12.0",
     "@turf/boolean-intersects": "^7.3.5",
     "@turf/turf": "^7.3.5",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { VStack, Box } from '@chakra-ui/react';
+import { VStack, Box, Text } from '@chakra-ui/react';
 import { observer } from 'mobx-react';
 import WorldMap from './WorldMap';
 import ControlPanel from './ControlPanel';
@@ -9,6 +9,59 @@ import Statistics from './Statistics';
 import Documentation from './Documentation';
 import ColorMode from './ControlPanel/ColorMode';
 import BackendSelect from './BackendSelect';
+import { formatThousands } from '../utils/formats';
+
+// Tooltip for the hovered tree branch/node: the clade's reconstructed ancestral range,
+// each bioregion sized by its share of the clade's occurrences. The matching bioregions are
+// simultaneously emphasized on the map (see TreeStore.onHover / MapStore.highlightBioregions).
+const TreeTooltip = observer(function _TreeTooltip() {
+  const { treeStore } = useStore();
+  const info = treeStore.hoverInfo;
+  if (!info) {
+    return null;
+  }
+  const [x, y] = treeStore.hoverPos;
+  return (
+    <Box
+      position="absolute"
+      left={`${x + 12}px`}
+      top={`${y + 12}px`}
+      pointerEvents="none"
+      bg="rgba(255,255,255,0.96)"
+      border="1px solid #cccccc"
+      borderRadius="3px"
+      px={2}
+      py={1}
+      fontSize="xs"
+      lineHeight="1.4"
+      zIndex={10}
+      boxShadow="sm"
+      maxW="240px"
+    >
+      {info.name && (
+        <Text fontWeight="600" truncate>
+          {info.name}
+        </Text>
+      )}
+      <Text color="gray.500" mb={1}>
+        Ancestral range · {formatThousands(info.speciesCount)} tips
+      </Text>
+      {info.regions.map((r) => (
+        <Box key={r.clusterId} display="flex" alignItems="center" gap={1.5}>
+          <Box
+            w="10px"
+            h="10px"
+            borderRadius="2px"
+            bg={r.color}
+            flexShrink={0}
+          />
+          <Text flex={1}>Bioregion {r.clusterId}</Text>
+          <Text color="gray.500">{Math.round(r.fraction * 100)}%</Text>
+        </Box>
+      ))}
+    </Box>
+  );
+});
 
 const PhyloTree = observer(function _PhyloTree() {
   const { treeStore } = useStore();
@@ -28,16 +81,18 @@ const PhyloTree = observer(function _PhyloTree() {
   }
 
   return (
-    <Box ml={4} position="relative" width={treeStore.width}>
+    <Box ml={4} width={treeStore.width}>
       <BackendSelect value={treeStore.backend} onChange={treeStore.setBackend} />
-      <div
-        ref={hostRef}
-        style={{
-          position: 'relative',
-          width: treeStore.width,
-          height: treeStore.height,
-        }}
-      />
+      {/* Relative wrapper sized to the canvas: the hover tooltip is positioned in the same
+          coordinate space as the d3gl pointer offsets. */}
+      <Box
+        position="relative"
+        width={treeStore.width}
+        height={treeStore.height}
+      >
+        <div ref={hostRef} style={{ position: 'absolute', inset: 0 }} />
+        <TreeTooltip />
+      </Box>
     </Box>
   );
 });

--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -1,53 +1,70 @@
 import { useEffect, useRef } from 'react';
 import { observer } from 'mobx-react';
 import { useStore } from '../store/';
-import { Badge, Box, Card, Heading, Text } from '@chakra-ui/react';
+import { Box, Text } from '@chakra-ui/react';
 import { formatThousands } from '../utils/formats';
 import BackendSelect from './BackendSelect';
 
-const Tooltip = observer(function _Tooltip() {
-  const { mapStore, infomapStore, treeStore } = useStore();
-  const { tooltipCell: cell } = mapStore;
-  const { timeFormatter } = treeStore;
-
+// Tooltip for the hovered grid cell: id, size/area, and — once bioregions are computed — a
+// colored bioregion badge and the clade's oldest tree-node time. Driven by d3gl's native
+// `hover` event (clip-aware picking on the cells layer); content is rendered declaratively
+// here rather than built imperatively in the store (cf. TreeTooltip in App.tsx).
+const MapTooltip = observer(function _MapTooltip() {
+  const { mapStore, infomapStore, treeStore, colorStore } = useStore();
+  const cell = mapStore.hoverCell;
   if (!cell) {
     return null;
   }
-  const bioregion = infomapStore.bioregions.find(
-    (b) => b.bioregionId === cell.bioregionId,
-  );
-
-  const [x, y] = mapStore.tooltipPos;
+  const [x, y] = mapStore.hoverPos;
+  const bioregion = cell.bioregionId
+    ? infomapStore.bioregions.find((b) => b.bioregionId === cell.bioregionId)
+    : undefined;
   return (
-    <Box pos="absolute" left={x} top={y} pointerEvents="none">
-      <Card.Root bgColor="rgba(255,255,255,0.2)">
-        <Card.Header p={2}>
-          <Heading size="xs">
-            Cell <small style={{ color: '#cccccc' }}>{cell.id}</small>
-          </Heading>
-          <Text style={{ display: 'inline-block' }}>
-            {cell.sizeString}
-            <small>×</small>
-            {cell.sizeString}
-          </Text>
-          <Text fontSize="xs" style={{ display: 'inline-block' }}>
-            ({formatThousands(Math.round(cell.area))} km²)
-          </Text>
-        </Card.Header>
-        <Card.Body p={2} pt={0}>
-          <Box>
-            <Badge bgColor={cell.color}>Bioregion {cell.bioregionId}</Badge>
-          </Box>
-          {bioregion && (
-            <Box>
-              <Text>
-                Oldest tree node:{' '}
-                {`${timeFormatter(bioregion.oldestPhyloNodeTime)} (t=${bioregion.oldestPhyloNodeTime.toFixed(2)})`}
-              </Text>
-            </Box>
-          )}
-        </Card.Body>
-      </Card.Root>
+    <Box
+      position="absolute"
+      left={`${x + 12}px`}
+      top={`${y + 12}px`}
+      pointerEvents="none"
+      bg="rgba(255,255,255,0.96)"
+      border="1px solid #cccccc"
+      borderRadius="3px"
+      px={2}
+      py={1}
+      fontSize="xs"
+      lineHeight="1.4"
+      zIndex={10}
+      boxShadow="sm"
+      maxW="240px"
+    >
+      <Text fontWeight="600">
+        Cell{' '}
+        <Text as="span" color="gray.500" fontWeight="400">
+          {cell.id}
+        </Text>
+      </Text>
+      <Text color="gray.500">
+        {cell.sizeString}×{cell.sizeString} (
+        {formatThousands(Math.round(cell.area))} km²)
+      </Text>
+      {!!cell.bioregionId && (
+        <Box display="flex" alignItems="center" gap={1.5} mt={1}>
+          <Box
+            w="10px"
+            h="10px"
+            borderRadius="2px"
+            bg={colorStore.colorBioregion(cell.bioregionId)}
+            flexShrink={0}
+          />
+          <Text>Bioregion {cell.bioregionId}</Text>
+        </Box>
+      )}
+      {bioregion && (
+        <Text color="gray.500">
+          Oldest tree node:{' '}
+          {treeStore.timeFormatter(bioregion.oldestPhyloNodeTime)} (t=
+          {bioregion.oldestPhyloNodeTime.toFixed(2)})
+        </Text>
+      )}
     </Box>
   );
 });
@@ -67,17 +84,15 @@ export default observer(function WorldMap() {
   }, [mapStore]);
 
   return (
-    <Box ml={4} position="relative" width={width}>
+    <Box ml={4} width={width}>
       <BackendSelect value={mapStore.backend} onChange={mapStore.setBackend} />
-      <div
-        ref={hostRef}
-        style={{ position: 'relative', width, height }}
-        onMouseMove={mapStore.onMouseMove}
-        onMouseOver={mapStore.onMouseEnter}
-        onMouseOut={mapStore.onMouseLeave}
-        onClick={mapStore.onMouseClick}
-      />
-      <Tooltip />
+      {/* Relative wrapper sized to the canvas: the hover tooltip is positioned in the same
+          coordinate space as the d3gl pointer offsets. Hover outline + selection dimming are
+          handled natively by d3gl on the cells layer (see MapStore.buildLayers). */}
+      <Box position="relative" width={width} height={height}>
+        <div ref={hostRef} style={{ position: 'absolute', inset: 0 }} />
+        <MapTooltip />
+      </Box>
     </Box>
   );
 });

--- a/src/store/MapStore.ts
+++ b/src/store/MapStore.ts
@@ -8,12 +8,9 @@ import {
   type GeoMap,
   type BackendType,
   type LayerHandle,
+  type HoverHit,
 } from '@mapequation/d3gl/map';
-import {
-  fitProjection,
-  lonLatFromScreen,
-  type ViewTransform,
-} from '@mapequation/d3gl/geo';
+import { fitProjection } from '@mapequation/d3gl/geo';
 
 export const BACKENDS: BackendType[] = ['auto', 'canvas', 'svg'];
 
@@ -93,10 +90,6 @@ export default class MapStore {
   // The layer is registered with a `() => multiPoints` callback, so pan/zoom/projection repaints
   // re-read and re-project everything (time-sliced by d3gl) — append only covers the new delta.
   private pointsHandle: LayerHandle<MultiPoint> | null = null;
-  // Current d3gl view transform (screen-space pan/zoom for flat projections), kept in sync via
-  // enableZoom so hover can invert screen → lon/lat. Orthographic keeps rotation in the
-  // projection itself, so the transform stays at identity there.
-  transform: ViewTransform = { k: 1, x: 0, y: 0 };
 
   width: number = 1200;
   height: number = 900;
@@ -111,14 +104,16 @@ export default class MapStore {
   waterColor: string = '#f0f8ff';
   landColor: string = '#ffffff';
 
-  tooltipActive: boolean = false;
-  tooltipPos: [number, number] = [0, 0];
-  tooltipCell: Cell | null = null;
-
   heatmapTarget: HeatmapTarget = 'records';
   get heatmapScale(): 'linear' | 'log' {
     return HEATMAP_TARGET_SCALE[this.heatmapTarget];
   }
+
+  // Hover state for the React tooltip, set from d3gl's native `hover` event (clip-aware
+  // picking on the cells layer). The tooltip content is a React component (see WorldMap),
+  // not built imperatively here.
+  hoverCell: Cell | null = null;
+  hoverPos: [number, number] = [0, 0];
 
   constructor(rootStore: RootStore) {
     this.rootStore = rootStore;
@@ -136,9 +131,9 @@ export default class MapStore {
       colorModuleParticipationStrength: observable,
       waterColor: observable,
       landColor: observable,
-      tooltipActive: observable,
-      tooltipPos: observable,
-      tooltipCell: observable.ref,
+      hoverCell: observable.ref,
+      hoverPos: observable.ref,
+      setHover: action,
       heatmapTarget: observable,
       heatmapScale: computed,
       backend: observable,
@@ -298,11 +293,12 @@ export default class MapStore {
     this.engine = engine;
 
     // One call for every projection: d3gl auto-dispatches drag-to-rotate (versor) for the
-    // orthographic globe and affine pan/zoom for flat projections.
-    engine.enableZoom([1, 12], (t) => {
-      this.transform = t;
-    });
+    // orthographic globe and affine pan/zoom for flat projections. Hover/click picking
+    // inverts screen → data internally, so we no longer track the transform ourselves.
+    engine.enableZoom([1, 18]);
 
+    // Clip-aware picking on the cells layer drives the React tooltip (see WorldMap.MapTooltip).
+    engine.on('hover', this.onHover);
   }
 
   /**
@@ -340,6 +336,12 @@ export default class MapStore {
         fill: (cell: Cell) => getGridColor(cell),
         clipTo,
         id: (cell: Cell) => cell.id,
+        // Native d3gl interaction (clip-aware): outline the hovered cell into a tiny overlay
+        // (the grid's buffers are untouched), and let `select()` dim non-members — driven from
+        // the tree's ancestral-range hover (see `highlightBioregions`). The hover *event*
+        // (engine.on('hover')) feeds the React tooltip; the tooltip content lives in WorldMap.
+        hover: { stroke: '#000000', lineWidth: 1.5 },
+        selection: { others: { opacity: 0.25 } },
         // hideOnInteraction: true,
       });
     }
@@ -416,7 +418,6 @@ export default class MapStore {
       this.width,
       this.height,
     );
-    this.transform = { k: 1, x: 0, y: 0 };
     this.engine?.setProjection(this.projection);
   }
 
@@ -432,44 +433,32 @@ export default class MapStore {
     projection.translate([width / 2, height / 2]);
   }
 
-  // --- Tooltip / hover (React mouse handlers on the host div) ---
+  // --- Hover tooltip + cross-highlight (native d3gl interaction) ---
 
-  getPosFromEvent(event: React.MouseEvent<HTMLElement>): [number, number] {
-    const { offsetX, offsetY } = event.nativeEvent;
-    return [offsetX, offsetY];
-  }
+  /** Track the hovered grid cell + pointer position for the React tooltip. Fires from d3gl's
+   *  clip-aware `hover` event; `null` (off a cell / off the painted grid) hides the tooltip. */
+  private onHover = (hit: HoverHit | null, ev: PointerEvent) => {
+    this.setHover(
+      hit?.layer === 'cells' ? (hit.datum as Cell) : null,
+      [ev.offsetX, ev.offsetY],
+    );
+  };
 
-  setTooltipPos = action((event: React.MouseEvent<HTMLElement>) => {
-    this.tooltipPos = this.getPosFromEvent(event);
+  setHover = action((cell: Cell | null, pos: [number, number]) => {
+    this.hoverCell = cell;
+    this.hoverPos = pos;
   });
 
-  onMouseEnter = action((event: React.MouseEvent<HTMLElement>) => {
-    this.tooltipActive = true;
-    this.setTooltipPos(event);
-  });
-
-  onMouseLeave = action(() => {
-    this.tooltipActive = false;
-    this.tooltipCell = null;
-  });
-
-  onMouseMove = action((event: React.MouseEvent<HTMLElement>) => {
-    this.setTooltipPos(event);
-    const [x, y] = this.tooltipPos;
-    // Orthographic keeps its rotation in the projection (transform stays identity), so invert
-    // directly; flat projections invert through the affine view transform. invert() returns
-    // null off the globe / outside the sphere.
-    const longlat =
-      this.projectionName === 'geoOrthographic'
-        ? (this.projection.invert?.([x, y]) ?? null)
-        : lonLatFromScreen(this.projection, this.transform, x, y);
-    if (!longlat) {
-      this.tooltipCell = null;
+  /** Emphasize a set of bioregions on the map by dimming every cell that isn't a member
+   *  (one style-table write via `select`, no re-tessellation). Driven by the tree's
+   *  ancestral-range hover so a clade's reconstructed range lights up geographically.
+   *  `null` (or an empty set) clears the selection. No-op in records mode (no cells layer). */
+  highlightBioregions = action((regionIds: Set<number> | null) => {
+    if (this.engine === null) return;
+    if (regionIds === null || regionIds.size === 0) {
+      this.engine.select('cells', null);
       return;
     }
-    const cell = this.rootStore.speciesStore.binner.find(...longlat) ?? null;
-    this.tooltipCell = cell?.visible ? cell : null;
+    this.engine.select('cells', (cell: Cell) => regionIds.has(cell.bioregionId));
   });
-
-  onMouseClick = action((_event: React.MouseEvent<HTMLElement>) => { });
 }

--- a/src/store/TreeStore.ts
+++ b/src/store/TreeStore.ts
@@ -34,7 +34,12 @@ import { scaleLinear } from 'd3-scale';
 // d3 umbrella has the shape/scale helpers (d3-shape, d3-scale are transitive via `d3`).
 import { scaleSqrt } from 'd3';
 import { isEqual } from '../utils/math';
-import { plot, type Plot, type BackendType } from '@mapequation/d3gl/map';
+import {
+  plot,
+  type Plot,
+  type BackendType,
+  type HoverHit,
+} from '@mapequation/d3gl/map';
 import { LabelLayer, type LabelAnchor } from '@mapequation/d3gl/labels';
 import type { ViewTransform } from '@mapequation/d3gl/geo';
 
@@ -62,6 +67,24 @@ interface Wedge {
   a1: number;
   clusterId: number;
   single: boolean;
+  node: LayoutNode;
+}
+
+/** One reconstructed-range slice for the hover tooltip: a bioregion, its share of the
+ *  clade's occurrences, and the bioregion color. */
+export interface HoverRegion {
+  clusterId: number;
+  count: number;
+  fraction: number;
+  color: string;
+}
+
+/** Ancestral-range summary of the hovered tree node/branch, shown in the tree tooltip
+ *  while the matching bioregions are emphasized on the map. */
+export interface TreeHoverInfo {
+  name: string;
+  speciesCount: number;
+  regions: HoverRegion[];
 }
 
 export default class TreeStore {
@@ -91,6 +114,16 @@ export default class TreeStore {
   private view: ViewTransform = { k: 1, x: 0, y: 0 };
   private renderDisposer: IReactionDisposer | null = null;
 
+  // Latest ancestral-range reconstruction (node → ranges/distribution), looked up on hover.
+  // Kept off the observable graph: it's rebuilt by `renderTree` and read by `onHover`.
+  private ancestral: AncestralMap | null = null;
+  // The tree layer currently showing a manual hover outline, so it can be cleared on hover-out.
+  private hoverLayer: string | null = null;
+
+  // Hover state for the React tooltip (set from the d3gl `hover` event).
+  hoverInfo: TreeHoverInfo | null = null;
+  hoverPos: [number, number] = [0, 0];
+
   constructor(rootStore: RootStore) {
     this.rootStore = rootStore;
 
@@ -107,6 +140,9 @@ export default class TreeStore {
       layout: observable,
       curve: observable,
       coords: observable,
+      hoverInfo: observable.ref,
+      hoverPos: observable.ref,
+      setHoverInfo: action,
       setLayout: action,
       setCurve: action,
       setCoords: action,
@@ -305,11 +341,16 @@ export default class TreeStore {
       this.updateLabels();
     });
 
+    // Native d3gl picking (clip-aware): hovering a branch or node pie reads out that clade's
+    // reconstructed ancestral range — shown in the tree tooltip and cross-highlighted on the map.
+    engine.on('hover', this.onHover);
+
     // Rebuild whenever the tree, bioregions, or colors change (autorun tracks the reads).
     this.renderDisposer = autorun(() => this.renderTree());
   }
 
   disposeEngine = () => {
+    this.clearHover();
     this.renderDisposer?.();
     this.renderDisposer = null;
     this.labels?.destroy();
@@ -357,6 +398,8 @@ export default class TreeStore {
 
     const tree = this.tree;
     if (tree === null) {
+      this.clearHover();
+      this.ancestral = null;
       engine.layer('links', [], { draw: () => {} });
       engine.layer('pies', [], { draw: () => {} });
       this.anchors = [];
@@ -380,6 +423,7 @@ export default class TreeStore {
     let screenRadius: ((n: number) => number) | null = null;
     if (haveBioregions) {
       ancestral = reconstructAncestralRanges(tree, this.getClustersPerSpecies());
+      this.ancestral = ancestral;
       const total = ancestral.get(tree)?.speciesCount ?? 1;
       const ws = scaleSqrt().domain([1, total]).range([LINE_MIN, LINE_MAX]);
       const rs = scaleSqrt().domain([1, total]).range([PIE_MIN, PIE_MAX]);
@@ -427,7 +471,16 @@ export default class TreeStore {
         const r = pieRadius(n);
         const single = slices.length === 1;
         for (const s of slices) {
-          wedges.push({ cx, cy, r, a0: s.a0, a1: s.a1, clusterId: s.clusterId, single });
+          wedges.push({
+            cx,
+            cy,
+            r,
+            a0: s.a0,
+            a1: s.a1,
+            clusterId: s.clusterId,
+            single,
+            node: n,
+          });
         }
       }
       engine.layer('pies', wedges, {
@@ -452,6 +505,9 @@ export default class TreeStore {
         id: (_w, i) => i,
       });
     } else {
+      // No bioregions yet: no ancestral ranges to hover, so drop any stale reconstruction/hover.
+      this.ancestral = null;
+      this.clearHover();
       engine.layer('pies', [], { draw: () => {} });
     }
 
@@ -477,6 +533,79 @@ export default class TreeStore {
     engine.render();
     this.updateLabels();
   }
+
+  // --- Hover: show a node's ancestral range (tree tooltip + map cross-highlight) ---
+
+  /** Resolve the tree node behind a hover hit: a branch (`links` → its child node) or a node pie. */
+  private nodeFromHit(hit: HoverHit | null): LayoutNode | undefined {
+    if (!hit) return undefined;
+    if (hit.layer === 'pies') return (hit.datum as Wedge | null)?.node;
+    if (hit.layer === 'links') return (hit.datum as LayoutLink | null)?.target;
+    return undefined;
+  }
+
+  private onHover = (hit: HoverHit | null, ev: PointerEvent) => {
+    const node = this.nodeFromHit(hit);
+    const data = node ? this.ancestral?.get(node.data) : undefined;
+    if (!hit || !node || !data) {
+      this.clearHover();
+      return;
+    }
+    const slices = this.pieSlices(data);
+    if (slices.length === 0) {
+      this.clearHover();
+      return;
+    }
+
+    // Outline the hovered branch/pie in the tree's overlay layer (clearing a previous one on
+    // another layer first); the base geometry is untouched, so this is one feature per change.
+    // Branches: black overdraw at the branch's own width. Pies: a 1.5px black outline (their
+    // base lineWidth is 0 for single-region nodes, so the default white outline would vanish).
+    if (this.hoverLayer && this.hoverLayer !== hit.layer) {
+      this.engine?.highlight(this.hoverLayer, null);
+    }
+    this.hoverLayer = hit.layer;
+    this.engine?.highlight(
+      hit.layer,
+      hit.id,
+      hit.layer === 'pies'
+        ? { stroke: '#000000', lineWidth: 1.5 }
+        : { stroke: '#000000' },
+    );
+
+    // Light up the same bioregions on the map (dims the rest via the cells' `selection`).
+    this.rootStore.mapStore.highlightBioregions(
+      new Set(slices.map((s) => s.clusterId)),
+    );
+
+    const regions: HoverRegion[] = slices.map((s) => ({
+      clusterId: s.clusterId,
+      count: s.count,
+      // The slice already encodes the count-weighted share as its arc (with an equal-slice
+      // fallback when every region has zero count), so derive the fraction from the angle.
+      fraction: (s.a1 - s.a0) / (2 * Math.PI),
+      color: this.regionColor(s.clusterId),
+    }));
+    this.setHoverInfo(
+      { name: node.data.name, speciesCount: data.speciesCount, regions },
+      [ev.offsetX, ev.offsetY],
+    );
+  };
+
+  /** Clear the hover overlay, the map cross-highlight, and the tooltip. */
+  clearHover = () => {
+    if (this.hoverLayer) {
+      this.engine?.highlight(this.hoverLayer, null);
+      this.hoverLayer = null;
+    }
+    this.rootStore.mapStore.highlightBioregions(null);
+    if (this.hoverInfo !== null) this.setHoverInfo(null, this.hoverPos);
+  };
+
+  setHoverInfo = action((info: TreeHoverInfo | null, pos: [number, number]) => {
+    this.hoverInfo = info;
+    this.hoverPos = pos;
+  });
 
   /** File extension for the current export format (SVG when the SVG backend is selected). */
   get imageExtension(): '.svg' | '.png' {


### PR DESCRIPTION
## Summary
Makes the phylogenetic tree interactive and modernizes the map's hover interaction using d3gl 0.5.0's clip-aware interaction layer.

- **Tree** — hovering a branch (`links`) or node pie (`pies`) outlines the hovered element, shows a React tooltip of the clade's reconstructed ancestral bioregions (count-weighted share), and cross-highlights the same bioregions on the map (dims the rest via the cells' `selection`).
- **Map** — replaces the hand-rolled React tooltip + manual screen→lon/lat inversion + `binner.find()` with d3gl's native clip-aware `hover` event, a `hover` outline, and `selection` dimming on the `cells` layer. Tooltip content stays a React component (`MapTooltip`), driven by an observable set from the hover event.
- Bumps `@mapequation/d3gl` to `^0.5.0`.

## Notes
- Tree `clusterId` and cell `bioregionId` share numbering (both from `InfomapStore` `countPerRegion` / `cell.bioregionId`), so the cross-highlight maps correctly.

## Verification
- `npx tsc -b` clean; `npx vite build` succeeds.
- Not yet exercised live in a browser (needs a full loaded-data + computed-bioregions session).

Fixes #64