### PR TITLE
fix: anchor BackendSelect to the map/tree column again

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -81,7 +81,7 @@ const PhyloTree = observer(function _PhyloTree() {
   }
 
   return (
-    <Box ml={4} width={treeStore.width}>
+    <Box ml={4} position="relative" width={treeStore.width}>
       <BackendSelect value={treeStore.backend} onChange={treeStore.setBackend} />
       {/* Relative wrapper sized to the canvas: the hover tooltip is positioned in the same
           coordinate space as the d3gl pointer offsets. */}

--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -84,7 +84,7 @@ export default observer(function WorldMap() {
   }, [mapStore]);
 
   return (
-    <Box ml={4} width={width}>
+    <Box ml={4} position="relative" width={width}>
       <BackendSelect value={mapStore.backend} onChange={mapStore.setBackend} />
       {/* Relative wrapper sized to the canvas: the hover tooltip is positioned in the same
           coordinate space as the d3gl pointer offsets. Hover outline + selection dimming are


### PR DESCRIPTION
## Summary
Fixes a regression from #65: the d3gl backend button group (`BackendSelect`, `position: absolute; top: 1; left: 1`) rendered on top of the sidebar in the top-left of the page.

#65 moved `position: relative` off the outer `WorldMap`/`PhyloTree` wrapper and onto an inner box that wraps only the canvas + tooltip — which does **not** contain `BackendSelect`. With no positioned ancestor, the overlay anchored to the viewport. This restores `position="relative"` on the outer wrapper so the overlay anchors to the map/tree column again; the inner relative box stays (it aligns the hover tooltip to the canvas).

## Verification
- `npx tsc -b` clean.