### PR TITLE
Clean up all Biome warnings (fix in code)

### DIFF
--- a/src/components/ControlPanel/Advanced.tsx
+++ b/src/components/ControlPanel/Advanced.tsx
@@ -62,10 +62,14 @@ export default observer(function Advanced() {
         const name = `${timeFormatter(t)} Ma`;
 
         saveAs(await mapStore.getImageBlob(), `${name}.png`);
-        //@ts-ignore
-        infomapStore.tree!.name = name;
+        const { tree } = infomapStore;
+        if (!tree) {
+          throw new Error('Infomap run produced no tree');
+        }
+        // @ts-expect-error - tree.name is not part of the public type but is set here for export
+        tree.name = name;
         const filename = `${name}.json`;
-        zip.file(filename, JSON.stringify(infomapStore.tree)!);
+        zip.file(filename, JSON.stringify(tree));
       }
 
       const zipFile = await zip.generateAsync({ type: 'blob' });
@@ -97,7 +101,7 @@ export default observer(function Advanced() {
         }
 
         const filename = `N ${N}.json`;
-        zip.file(filename, JSON.stringify(infomapStore.tree)!);
+        zip.file(filename, JSON.stringify(infomapStore.tree));
       }
 
       const zipFile = await zip.generateAsync({ type: 'blob' });
@@ -129,7 +133,7 @@ export default observer(function Advanced() {
         }
 
         const filename = `${seed}.json`;
-        zip.file(filename, JSON.stringify(infomapStore.tree)!);
+        zip.file(filename, JSON.stringify(infomapStore.tree));
       }
 
       const zipFile = await zip.generateAsync({ type: 'blob' });
@@ -164,7 +168,7 @@ export default observer(function Advanced() {
         }
 
         const filename = `Markov-time-${markovTime}.json`;
-        zip.file(filename, JSON.stringify(infomapStore.tree)!);
+        zip.file(filename, JSON.stringify(infomapStore.tree));
       }
 
       const zipFile = await zip.generateAsync({ type: 'blob' });

--- a/src/components/ControlPanel/ColorSettings.tsx
+++ b/src/components/ControlPanel/ColorSettings.tsx
@@ -38,7 +38,7 @@ export default observer(function ColorSettings() {
     renderType: typeof mapStore.renderType,
   ) => {
     return (e: { value: number[] }) => {
-      setValue([e.value[0]!, e.value[1]!]);
+      setValue([e.value[0], e.value[1]]);
       if (mapStore.renderType === renderType) {
         mapStore.render();
       }
@@ -95,7 +95,7 @@ export default observer(function ColorSettings() {
               label="Color scheme"
               value={[colorStore.scheme as string]}
               onValueChange={(e) => {
-                colorStore.setScheme(e.value[0]! as SchemeName);
+                colorStore.setScheme(e.value[0] as SchemeName);
                 if (mapStore.renderType === 'bioregions') {
                   mapStore.render();
                 }

--- a/src/components/ControlPanel/Export.tsx
+++ b/src/components/ControlPanel/Export.tsx
@@ -4,7 +4,7 @@ import { useStore } from '../../store';
 import type RootStore from '../../store/RootStore';
 import { saveBlob, stringToBlob } from '../../utils/exporter';
 import JSZip from 'jszip';
-//@ts-ignore
+// @ts-expect-error - shp-write ships no type declarations
 import shpWrite from 'shp-write';
 
 interface ExportProps {
@@ -120,7 +120,11 @@ export default observer(function Export({ rootStore }: ExportProps) {
       extension: '.treee',
       disabled: !infomapStore.treeString,
       getBlob: async () => {
-        return stringToBlob(infomapStore.treeString!);
+        const { treeString } = infomapStore;
+        if (treeString == null) {
+          throw new Error('No Infomap tree string available');
+        }
+        return stringToBlob(treeString);
       },
     },
     {

--- a/src/components/ControlPanel/Load.tsx
+++ b/src/components/ControlPanel/Load.tsx
@@ -61,7 +61,7 @@ export const LoadData = observer(function LoadData() {
   const [isOpen, setIsOpen] = useState(false);
   const [file, setFile] = useState<File>();
   const [header, setHeader] = useState<string[]>([]);
-  const [lines, setLines] = useState<any[]>([]);
+  const [lines, setLines] = useState<Record<string, string>[]>([]);
 
   const [nameColumn, setNameColumn] = useState<string>('');
   const [latColumn, setLatColumn] = useState<string>('');
@@ -110,7 +110,7 @@ export const LoadData = observer(function LoadData() {
         setNameColumn(name);
         setLatColumn(lat);
         setLongColumn(long);
-        setLines(data);
+        setLines(data as Record<string, string>[]);
       } catch (e) {
         console.error(e);
       }

--- a/src/components/ControlPanel/Modal.tsx
+++ b/src/components/ControlPanel/Modal.tsx
@@ -12,7 +12,7 @@ import type { Dialog } from '@chakra-ui/react';
 
 type MyModalProps = {
   header: string;
-  footer?: React.ReactElement<any>;
+  footer?: React.ReactElement;
 } & Dialog.RootProps;
 
 export default function Modal({

--- a/src/components/Demo/DemoTree.tsx
+++ b/src/components/Demo/DemoTree.tsx
@@ -29,6 +29,17 @@ type Pos = [number, number];
 
 const layout = d3.tree<PhyloNode>();
 
+/**
+ * Assert that a value derived from the network/maps is present, throwing at the
+ * same point a non-null assertion would have failed on a null/undefined access.
+ */
+const required = <T,>(value: T | null | undefined, message: string): T => {
+  if (value == null) {
+    throw new Error(message);
+  }
+  return value;
+};
+
 export default observer(
   ({
     beta,
@@ -193,7 +204,10 @@ export default observer(
         return '';
       }
       const physId = 'states' in network ? network.states[nodeId].id : nodeId;
-      return network.nodes[physId].name!;
+      return required(
+        network.nodes[physId].name,
+        `Network node ${physId} has no name`,
+      );
     };
 
     const { nameToCellIds } = binner;
@@ -201,8 +215,11 @@ export default observer(
       // source: tree node, target: grid cell
       const taxonName = getPhysName(link.source);
       const cellName = getPhysName(link.target);
-      const treeNode = nodeMap.get(taxonName)!;
-      const cell = cellMap.get(cellName)!;
+      const treeNode = required(
+        nodeMap.get(taxonName),
+        `No tree node for ${taxonName}`,
+      );
+      const cell = required(cellMap.get(cellName), `No cell for ${cellName}`);
       const weight = link.weight ?? 0;
 
       return { treeNode, cell, weight };
@@ -244,15 +261,20 @@ export default observer(
         .forEach(({ name: cellStateName }) => {
           // const cellId = network.nodes[id].name!;
           const [cellId, memTaxonId] = (cellStateName ?? '_').split('_');
-          const memTreeNode = nodeMap.get(memTaxonId)!;
-          const cell = cellMap.get(cellId)!;
+          const memTreeNode = required(
+            nodeMap.get(memTaxonId),
+            `No tree node for ${memTaxonId}`,
+          );
+          const cell = required(cellMap.get(cellId), `No cell for ${cellId}`);
           const cellPos = projection(cell.center) ?? [0, 0];
           const stateCells = cellIdToStates.get(cellId) ?? [];
           if (stateCells.length === 0) {
             cellIdToStates.set(cellId, stateCells);
           }
-          const bioregionId =
-            cell.overlappingBioregions.memoryIdToBioregion.get(memTaxonId)!;
+          const bioregionId = required(
+            cell.overlappingBioregions.memoryIdToBioregion.get(memTaxonId),
+            `No bioregion for memory taxon ${memTaxonId}`,
+          );
           stateCells.push({
             cellStateName: cellStateName ?? '',
             cellId,
@@ -271,25 +293,37 @@ export default observer(
       });
 
       network.links.forEach(({ source, target, weight }) => {
-        const treeNodeName = network.states[source].name!;
-        const treeNode = nodeMap.get(treeNodeName)!;
-        const cellStateName = network.states[target].name!;
+        const treeNodeName = required(
+          network.states[source].name,
+          `Source state ${source} has no name`,
+        );
+        const treeNode = required(
+          nodeMap.get(treeNodeName),
+          `No tree node for ${treeNodeName}`,
+        );
+        const cellStateName = network.states[target].name;
         const [cellId, memTaxonId] = (cellStateName ?? '_').split('_');
-        const stateCells = cellIdToStates.get(cellId)!;
-        const stateCell = stateCells.find(
-          (stateCell) => stateCell.memTaxonId === memTaxonId,
-        )!;
+        const stateCells = required(
+          cellIdToStates.get(cellId),
+          `No state cells for ${cellId}`,
+        );
+        const stateCell = required(
+          stateCells.find(
+            (stateCell) => stateCell.memTaxonId === memTaxonId,
+          ),
+          `No state cell for memory taxon ${memTaxonId}`,
+        );
         stateLinks.push({
           treeNode,
           stateCell,
-          weight: weight!,
+          weight: required(weight, 'State link has no weight'),
         });
       });
 
       // Set internal y pos based on memory taxon position
       cellIdToStates.forEach((stateCells) => {
         const numStates = stateCells.length;
-        const { cellPos } = stateCells[0]!;
+        const { cellPos } = stateCells[0];
         const startY = cellPos[1] - cellSize / 2;
         const dy = cellSize / (numStates + 1);
         stateCells.forEach((stateCell, i) => {

--- a/src/components/Statistics/Bioregions.tsx
+++ b/src/components/Statistics/Bioregions.tsx
@@ -129,7 +129,7 @@ const BioregionInfo = observer(function Bioregion({
               commonSpecies: { name: string; count: number; score: number },
               index: number,
             ) => {
-              const indicativeSpecies = mostIndicative[index]!;
+              const indicativeSpecies = mostIndicative[index];
               return (
                 <Table.Row
                   key={`${commonSpecies.name}|${indicativeSpecies.name}`}

--- a/src/components/StatusBar/icons.tsx
+++ b/src/components/StatusBar/icons.tsx
@@ -42,7 +42,10 @@ function distinctFills(r1: string, r2: string) {
  */
 function fuzzyFills(r1: string, r2: string) {
   const blend = (t: number, opacity: number) => {
-    const c = d3color(interpolateRgb(r2, r1)(t))!; // interpolateRgb(secondColor, firstColor)
+    const c = d3color(interpolateRgb(r2, r1)(t)); // interpolateRgb(secondColor, firstColor)
+    if (!c) {
+      throw new Error('Failed to parse interpolated color');
+    }
     c.opacity = opacity;
     return c.toString();
   };

--- a/src/components/TangleInput.tsx
+++ b/src/components/TangleInput.tsx
@@ -109,7 +109,11 @@ export default function TangleInput({
       const lastX = e.screenX;
 
       // const pixelChange = lastX - startX;
-      const pixelChange = lastX - refState.current.lastX!;
+      const { lastX: prevX } = refState.current;
+      if (prevX === undefined) {
+        throw new Error('TangleInput: lastX not initialized on mouse move');
+      }
+      const pixelChange = lastX - prevX;
       const numSteps =
         pixelChange > 0
           ? Math.floor(speed * pixelChange)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,7 +9,12 @@ import { Provider } from '@/components/ui/provider';
 import theme from './theme';
 import store, { StoreContext } from './store';
 
-createRoot(document.getElementById('root')!).render(
+const rootElement = document.getElementById('root');
+if (!rootElement) {
+  throw new Error('Root element #root not found');
+}
+
+createRoot(rootElement).render(
   <StrictMode>
     <Provider system={theme}>
       <StoreContext.Provider value={store}>

--- a/src/store/ColorStore.ts
+++ b/src/store/ColorStore.ts
@@ -5,6 +5,19 @@ import type RootStore from './RootStore';
 import type { Cell } from '../utils/QuadTree';
 import { color as Color, interpolateRgb } from 'd3';
 
+// `d3.color` returns null for an unparseable color specifier. The call sites below
+// previously used a non-null assertion (`!`) and would have thrown on the subsequent
+// property access; this helper preserves that "throw on null" behavior with a clearer
+// message while keeping a non-nullable return type.
+type D3Color = NonNullable<ReturnType<typeof Color>>;
+const requireColor = (specifier: string): D3Color => {
+  const color = Color(specifier);
+  if (color == null) {
+    throw new Error(`Invalid color specifier: ${specifier}`);
+  }
+  return color;
+};
+
 export type SchemeName = c3SchemeName | 'Mural';
 
 export const COLOR_SCHEMES = [
@@ -90,7 +103,7 @@ export class CellColor {
   }
 
   generateColor(colorModuleParticipationStrength = 1) {
-    const color = Color(interpolateRgb(this.secondColor, this.firstColor)(this.t ** colorModuleParticipationStrength))!;
+    const color = requireColor(interpolateRgb(this.secondColor, this.firstColor)(this.t ** colorModuleParticipationStrength));
     color.opacity = this.opacity ** colorModuleParticipationStrength;
     return color.toString();
   }
@@ -216,13 +229,13 @@ export default class ColorStore {
           const firstColor = colorBioregion(cell.bioregionId);
           const secondColor = colorBioregion(topBioregionId);
           t = ownProportion / (ownProportion + topBioregionProportion)
-          const color = Color(interpolateRgb(secondColor, firstColor)(t ** colorModuleParticipationStrength))!;
+          const color = requireColor(interpolateRgb(secondColor, firstColor)(t ** colorModuleParticipationStrength));
           color.opacity = topBioregionProportion ** colorModuleParticipationStrength;
           return new CellColor(firstColor, secondColor, t, color.opacity);
         }
         const firstColor = colorBioregion(topBioregionId);
         const secondColor = colorBioregion(secondBioregionId);
-        const color = Color(interpolateRgb(secondColor, firstColor)(t ** colorModuleParticipationStrength))!;
+        const color = requireColor(interpolateRgb(secondColor, firstColor)(t ** colorModuleParticipationStrength));
         color.opacity = topBioregionProportion ** colorModuleParticipationStrength;
         return color.toString();
       }
@@ -235,7 +248,7 @@ export default class ColorStore {
         secondBioregionProportion,
       } = cell.overlappingBioregions;
       if (this.hideDominantOverlappingModule) {
-        const color = Color(colorBioregion(secondBioregionId))!;
+        const color = requireColor(colorBioregion(secondBioregionId));
         color.opacity = secondBioregionProportion;// / (1 - topBioregionProportion);
         return color.toString();
       }
@@ -244,7 +257,7 @@ export default class ColorStore {
         (topBioregionProportion + secondBioregionProportion);
       const firstColor = colorBioregion(topBioregionId);
       const secondColor = colorBioregion(secondBioregionId);
-      const color = Color(interpolateRgb(secondColor, firstColor)(t))!;
+      const color = requireColor(interpolateRgb(secondColor, firstColor)(t));
       color.opacity = topBioregionProportion;
       return color.toString();
     }
@@ -261,7 +274,7 @@ export default class ColorStore {
       secondBioregionProportion,
     } = cell.overlappingBioregions;
     if (this.hideDominantOverlappingModule) {
-      const color = Color(colorBioregion(secondBioregionId))!;
+      const color = requireColor(colorBioregion(secondBioregionId));
       color.opacity = secondBioregionProportion;// / (1 - topBioregionProportion);
       return color.toString();
     }
@@ -270,7 +283,7 @@ export default class ColorStore {
       (topBioregionProportion + secondBioregionProportion);
     const firstColor = colorBioregion(topBioregionId);
     const secondColor = colorBioregion(secondBioregionId);
-    const color = Color(interpolateRgb(secondColor, firstColor)(t))!;
+    const color = requireColor(interpolateRgb(secondColor, firstColor)(t));
     color.opacity = topBioregionProportion;
     return color.toString();
   }
@@ -302,14 +315,14 @@ export default class ColorStore {
             const firstColor = colorBioregion(cell.bioregionId);
             const secondColor = colorBioregion(topBioregionId);
             t = ownProportion / (ownProportion + topBioregionProportion)
-            const color = Color(interpolateRgb(secondColor, firstColor)(t ** colorModuleParticipationStrength))!;
+            const color = requireColor(interpolateRgb(secondColor, firstColor)(t ** colorModuleParticipationStrength));
             color.opacity = topBioregionProportion ** colorModuleParticipationStrength;
             cell.color = color.toString();
             return cell.color;
           }
           const firstColor = colorBioregion(topBioregionId);
           const secondColor = colorBioregion(secondBioregionId);
-          const color = Color(interpolateRgb(secondColor, firstColor)(t ** colorModuleParticipationStrength))!;
+          const color = requireColor(interpolateRgb(secondColor, firstColor)(t ** colorModuleParticipationStrength));
           color.opacity = topBioregionProportion ** colorModuleParticipationStrength;
           cell.color = color.toString();
           return cell.color;
@@ -323,7 +336,7 @@ export default class ColorStore {
           secondBioregionProportion,
         } = cell.overlappingBioregions;
         if (this.hideDominantOverlappingModule) {
-          const color = Color(colorBioregion(secondBioregionId))!;
+          const color = requireColor(colorBioregion(secondBioregionId));
           color.opacity = secondBioregionProportion;// / (1 - topBioregionProportion);
           cell.color = color.toString();
           return cell.color;
@@ -333,7 +346,7 @@ export default class ColorStore {
           (topBioregionProportion + secondBioregionProportion);
         const firstColor = colorBioregion(topBioregionId);
         const secondColor = colorBioregion(secondBioregionId);
-        const color = Color(interpolateRgb(secondColor, firstColor)(t))!;
+        const color = requireColor(interpolateRgb(secondColor, firstColor)(t));
         color.opacity = topBioregionProportion;
         cell.color = color.toString();
         return cell.color;
@@ -353,7 +366,7 @@ export default class ColorStore {
         secondBioregionProportion,
       } = cell.overlappingBioregions;
       if (this.hideDominantOverlappingModule) {
-        const color = Color(colorBioregion(secondBioregionId))!;
+        const color = requireColor(colorBioregion(secondBioregionId));
         color.opacity = secondBioregionProportion;// / (1 - topBioregionProportion);
         cell.color = color.toString();
         return cell.color;
@@ -363,7 +376,7 @@ export default class ColorStore {
         (topBioregionProportion + secondBioregionProportion);
       const firstColor = colorBioregion(topBioregionId);
       const secondColor = colorBioregion(secondBioregionId);
-      const color = Color(interpolateRgb(secondColor, firstColor)(t))!;
+      const color = requireColor(interpolateRgb(secondColor, firstColor)(t));
       color.opacity = topBioregionProportion;
       cell.color = color.toString();
       return cell.color;

--- a/src/store/InfomapStore.ts
+++ b/src/store/InfomapStore.ts
@@ -19,7 +19,7 @@ import {
 import type { PhyloNode } from '../utils/tree';
 import { calculateStats, isEqual, uniformTsallisEntropy } from '../utils/math';
 import { range } from '../utils/range';
-import { max, min } from 'd3-array';
+import { max } from 'd3-array';
 import type { Cell } from '../utils/QuadTree';
 import type SpeciesStore from './SpeciesStore';
 import type TreeStore from './TreeStore';
@@ -107,9 +107,12 @@ export class Bioregion {
         continue;
       }
       for (const { count, name } of cell.speciesTopList) {
-        const species = speciesStore.speciesMap.get(name)!;
+        const species = speciesStore.speciesMap.get(name);
+        if (species == null) {
+          throw new Error(`InfomapStore: missing species '${name}'`);
+        }
 
-        const bioregionId = species.bioregionId!;
+        const bioregionId = species.bioregionId;
         if (!bioregionId) {
           // console.warn(`No bioregion id for species ${name}: ${bioregionId}`);
           ++numSpeciesWithoutBioregions;
@@ -137,7 +140,10 @@ export class Bioregion {
       this.mostIndicative.push({ name, score, count });
       this.mostCommon.push({ name, score, count });
 
-      const species = speciesStore.speciesMap.get(name)!;
+      const species = speciesStore.speciesMap.get(name);
+      if (species == null) {
+        throw new Error(`InfomapStore: missing species '${name}'`);
+      }
       species.countPerRegion.set(
         this.bioregionId,
         (species.countPerRegion.get(this.bioregionId) ?? 0) + count,
@@ -191,7 +197,7 @@ export class Bioregion {
       }
       const treeNode = treeStore.treeNodeMap.get(speciesName);
       if (treeNode) {
-        minTime = min([minTime, treeNode.data.time])!;
+        minTime = Math.min(minTime, treeNode.data.time);
       }
     }
     this.oldestPhyloNodeTime = minTime;
@@ -571,7 +577,10 @@ export default class InfomapStore {
     const phyloNodeWeights: Map<string, number> = new Map();
     const nodes = 'states' in network ? network.states : network.nodes;
     network.links.forEach(link => {
-      const taxonName = nodes[link.source].name!;
+      const taxonName = nodes[link.source].name;
+      if (taxonName == null) {
+        throw new Error(`InfomapStore: network node ${link.source} has no name`);
+      }
       phyloNodeWeights.set(taxonName, (link.weight ?? 0) / network.sumLinkWeight + (phyloNodeWeights.get(taxonName) ?? 0));
     })
     return getAccumulatedTreeData(phyloTree, {
@@ -614,7 +623,7 @@ export default class InfomapStore {
     console.log(`Infomap with id ${id} finished`)
 
     const { moduleLevel: _moduleLevel } = this;
-    const moduleLevel = tree ? min([_moduleLevel, tree.numLevels - 2])! : 0;
+    const moduleLevel = tree ? Math.min(_moduleLevel, tree.numLevels - 2) : 0;
     if (moduleLevel !== _moduleLevel) {
       this.setModuleLevel(moduleLevel, false);
     }
@@ -654,7 +663,10 @@ export default class InfomapStore {
     this.setIsRunning();
     this.setCurrentTrial(0);
 
-    const network = this.updateNetwork()!;
+    const network = this.updateNetwork();
+    if (network == null) {
+      throw new Error('InfomapStore: updateNetwork returned no network');
+    }
 
     const args = { ...this.args };
     // const isStateNetwork = 'states' in network;
@@ -734,7 +746,7 @@ export default class InfomapStore {
 
     try {
       await this.infomap.terminate(this.infomapId, 0);
-    } catch (e: any) {
+    } catch (e: unknown) {
       console.error('Worker error', e);
     }
     this.infomapId = null;
@@ -882,9 +894,10 @@ export default class InfomapStore {
           }
           sumNonTreeLinkWeight += weight;
           // TODO: No need to use the map here if not include tree, will not aggregate on species level
-          const outLinks = linkMap.has(name)
-            ? linkMap.get(name)!
-            : linkMap.set(name, new Map()).get(name)!;
+          const outLinks = linkMap.get(name) ?? new Map<CellId, Weight>();
+          if (!linkMap.has(name)) {
+            linkMap.set(name, outLinks);
+          }
           // if (!outLinks.has(cellId)) {
           //   ++network.numNonTreeLinks;
           // }
@@ -956,7 +969,10 @@ export default class InfomapStore {
       const links = new Map<CellId, Weight>();
       let numLinks = 0;
 
-      for (const species of node.speciesSet!) {
+      if (node.speciesSet == null) {
+        throw new Error(`InfomapStore: tree node '${node.name}' has no speciesSet`);
+      }
+      for (const species of node.speciesSet) {
         if (!nameToCellIds[species]) {
           missing.add(species);
           continue;
@@ -982,9 +998,10 @@ export default class InfomapStore {
     ) => {
       // TODO: Make sure internal tree nodes don't have same name as leaf nodes
 
-      const outLinks = treeLinks.has(node.name)
-        ? treeLinks.get(node.name)!
-        : treeLinks.set(node.name, new Map()).get(node.name)!;
+      const outLinks = treeLinks.get(node.name) ?? new Map<CellId, Weight>();
+      if (!treeLinks.has(node.name)) {
+        treeLinks.set(node.name, outLinks);
+      }
 
       for (const [cellId, count] of links.entries()) {
         const weight = count * interpolationWeight;
@@ -1165,20 +1182,27 @@ export default class InfomapStore {
       console.log(`=== Creating layer ${layerId} at time ${t}`);
       const network = this.createStandardNetwork(t);
       network.nodes.forEach((node) => {
-        if (multilayerNetwork.nodeIdMap[node.name!] === undefined) {
+        const { name } = node;
+        if (name == null) {
+          throw new Error(`InfomapStore: network node ${node.id} has no name`);
+        }
+        if (multilayerNetwork.nodeIdMap[name] === undefined) {
           const id = nodeIdCounter++;
-          multilayerNetwork.nodeIdMap[node.name!] = id;
-          multilayerNetwork.nodes?.push({ id, name: node.name! });
+          multilayerNetwork.nodeIdMap[name] = id;
+          multilayerNetwork.nodes?.push({ id, name });
         }
       });
       network.links.forEach((link) => {
-        const sourceName = network.nodes[link.source].name!;
-        const targetName = network.nodes[link.target].name!;
+        const sourceName = network.nodes[link.source].name;
+        const targetName = network.nodes[link.target].name;
+        if (sourceName == null || targetName == null) {
+          throw new Error('InfomapStore: network link references unnamed node');
+        }
         const intraLink = {
           layerId,
           source: multilayerNetwork.nodeIdMap[sourceName],
           target: multilayerNetwork.nodeIdMap[targetName],
-          weight: link.weight!,
+          weight: link.weight,
         }
         multilayerNetwork.intra.push(intraLink);
         // console.log(`${sourceName} -> ${targetName} (w: ${link.weight})`)
@@ -1286,7 +1310,10 @@ export default class InfomapStore {
 
     let stateIdCounter = 0;
     const addCellStateNode = (cellId: string, memTaxonName: string) => {
-      const cellPhysId = nameToPhysicalId.get(cellId)!;
+      const cellPhysId = nameToPhysicalId.get(cellId);
+      if (cellPhysId == null) {
+        throw new Error(`InfomapStore: missing physical id for cell '${cellId}'`);
+      }
       const stateName = getCellStateName(cellId, memTaxonName);
       let stateNode = cellStateNodes.get(stateName);
       if (stateNode == null) {
@@ -1349,13 +1376,22 @@ export default class InfomapStore {
     ) => {
       const cellStateNode = addCellStateNode(cellId, memTaxonName);
       const taxonNode = addTaxonNode(taxonName);
+      const taxonNodeName = taxonNode.name;
+      const cellStateNodeName = cellStateNode.name;
+      if (taxonNodeName == null || cellStateNodeName == null) {
+        throw new Error('InfomapStore: state node missing name');
+      }
 
       const outLinks =
-        linkMap.get(taxonNode.name!) ??
-        linkMap.set(taxonNode.name!, new Map()).get(taxonNode.name!)!;
+        linkMap.get(taxonNodeName) ??
+        (() => {
+          const m: StateCellOutLinks = new Map();
+          linkMap.set(taxonNodeName, m);
+          return m;
+        })();
       outLinks.set(
-        cellStateNode.name!,
-        (outLinks.get(cellStateNode.name!) ?? 0) + weight,
+        cellStateNodeName,
+        (outLinks.get(cellStateNodeName) ?? 0) + weight,
       );
     };
 
@@ -1364,8 +1400,11 @@ export default class InfomapStore {
         for (const [stateCellName, weight] of outLinks) {
           if (weight < linkWeightThreshold) { return; }
 
-          const taxonNode = phyloStateNodes.get(taxonName)!;
-          const cellStateNode = cellStateNodes.get(stateCellName)!;
+          const taxonNode = phyloStateNodes.get(taxonName);
+          const cellStateNode = cellStateNodes.get(stateCellName);
+          if (taxonNode == null || cellStateNode == null) {
+            throw new Error('InfomapStore: missing state node for link');
+          }
 
           network.links.push({
             source: taxonNode.stateId,
@@ -1412,7 +1451,10 @@ export default class InfomapStore {
           }
           continue;
         }
-        const memBranch = treeNode.data.memory!;
+        const memBranch = treeNode.data.memory;
+        if (memBranch == null) {
+          throw new Error(`InfomapStore: tree node '${name}' has no memory branch`);
+        }
 
         const unscaledWeight = this.getTaxonLinkWeightOnTimeSlice(cells.size, network.numGridCellNodes);
         const weight = (1 - treeWeightBalance) * unscaledWeight;
@@ -1481,12 +1523,19 @@ export default class InfomapStore {
       const links = new Map<TaxonName, Map<CellId, Weight>>();
       let sumWeight = 0;
 
-      for (const speciesName of node.speciesSet!) {
+      if (node.speciesSet == null) {
+        throw new Error(`InfomapStore: tree node '${node.name}' has no speciesSet`);
+      }
+      for (const speciesName of node.speciesSet) {
         if (!nameToCellIds[speciesName]) {
           missing.add(speciesName);
           continue;
         }
-        const memBranch = treeNodeMap.get(speciesName)!.data.memory!;
+        const speciesTreeNode = treeNodeMap.get(speciesName);
+        const memBranch = speciesTreeNode?.data.memory;
+        if (memBranch == null) {
+          throw new Error(`InfomapStore: tree node '${speciesName}' has no memory branch`);
+        }
         for (const memNode of [memBranch.parent, memBranch.child]) {
           const memTaxonName = memNode.name;
           const memWeight =
@@ -1675,7 +1724,10 @@ export default class InfomapStore {
       return;
     }
     const lines = ['*vertices'];
-    for (const node of network.nodes!) {
+    if (network.nodes == null) {
+      throw new Error('InfomapStore: multilayer network has no nodes');
+    }
+    for (const node of network.nodes) {
       lines.push(`${node.id} "${node.name}"`);
     }
     lines.push('*intra');
@@ -1707,7 +1759,7 @@ export default class InfomapStore {
     const { speciesStore, treeStore } = this.rootStore;
     const { cells, moduleLevel } = this;
     this.rootStore.clearBioregions();
-    const numModules = max(tree.nodes, (node) => node.modules[moduleLevel])!;
+    const numModules = max(tree.nodes, (node) => node.modules[moduleLevel]) ?? 0;
     // TODO: Some modules may have only tree nodes, reduce to number of modules containing grid cells
     console.log(`Create ${numModules} bioregions on level ${moduleLevel}`);
 
@@ -1730,7 +1782,7 @@ export default class InfomapStore {
       bioregion.bioregionId = bioregionId;
       bioregion.flow += node.flow;
 
-      if (node.id >= tree.bipartiteStartId!) {
+      if (node.id >= (tree.bipartiteStartId ?? Infinity)) {
         bioregion.species.push(node.name);
         const species = speciesStore.speciesMap.get(node.name);
         if (species) {
@@ -1759,11 +1811,14 @@ export default class InfomapStore {
     network.links.forEach(link => {
       const w = link.weight ?? 1.0;
       const cellId = network.nodes[link.target].id;
-      const taxonName = network.nodes[link.source].name!;
+      const taxonName = network.nodes[link.source].name;
+      if (taxonName == null) {
+        throw new Error(`InfomapStore: network node ${link.source} has no name`);
+      }
       let speciesBioregionId = 0;
       const species = speciesStore.speciesMap.get(taxonName);
       if (species) {
-        speciesBioregionId = species.bioregionId!;
+        speciesBioregionId = species.bioregionId ?? 0;
       } else {
         const treeNode = treeStore.treeNodeMap.get(taxonName);
         speciesBioregionId = treeNode?.bioregionId ?? 0;
@@ -1802,7 +1857,7 @@ export default class InfomapStore {
       this.addError(`Infomap output error, please report.`);
       return;
     }
-    const numModules = max(tree.nodes, (node) => node.modules[moduleLevel])!;
+    const numModules = max(tree.nodes, (node) => node.modules[moduleLevel]) ?? 0;
 
     const bioregions: Bioregion[] = Array.from(
       { length: numModules },
@@ -1836,9 +1891,15 @@ export default class InfomapStore {
       // TODO: Add state name to Infomap output?
       const stateName = (this.network as BioregionsStateNetwork).states[
         node.stateId
-      ].name!;
+      ].name;
+      if (stateName == null) {
+        throw new Error(`InfomapStore: state node ${node.stateId} has no name`);
+      }
       node.name = stateName;
-      const memTaxonName = stateName.split('_')[1]!;
+      const memTaxonName = stateName.split('_')[1];
+      if (memTaxonName == null) {
+        throw new Error(`InfomapStore: state name '${stateName}' has no memory part`);
+      }
 
       cell.bioregionId = bioregionId;
       cell.overlappingBioregions.addStateNode(
@@ -1869,7 +1930,7 @@ export default class InfomapStore {
       'Create multilayer bioregions... network:',
       this.multilayerNetwork,
     );
-    // @ts-ignore
+    // @ts-expect-error layers is an extra property attached to the multilayer tree
     tree.layers = this.multilayerNetwork?.layers;
     console.log(tree);
 

--- a/src/store/MapStore.ts
+++ b/src/store/MapStore.ts
@@ -16,7 +16,7 @@ export const BACKENDS: BackendType[] = ['auto', 'canvas', 'svg'];
 
 const sphere: d3.GeoPermissibleObjects = { type: 'Sphere' };
 
-export type IMapRenderer = {}
+export type IMapRenderer = Record<string, never>;
 
 export type RenderType = 'records' | 'heatmap' | 'bioregions';
 
@@ -38,6 +38,14 @@ export const PROJECTIONNAME: Record<Projection, string> = {
   geoOrthographic: 'Orthographic',
   geoMercator: 'Mercator',
 } as const;
+
+// Static lookup of the d3 projection factories keyed by projection name. Equivalent to
+// `d3[name]()` but uses explicit named references so the projections can be tree-shaken.
+const PROJECTION_FACTORIES: Record<Projection, () => d3.GeoProjection> = {
+  geoNaturalEarth1: d3.geoNaturalEarth1,
+  geoOrthographic: d3.geoOrthographic,
+  geoMercator: d3.geoMercator,
+};
 
 export const HEATMAP_TARGETS = [
   'records',
@@ -77,7 +85,7 @@ export default class MapStore {
   }
 
   projectionName: Projection = PROJECTIONS[0];
-  projection: d3.GeoProjection = d3[this.projectionName]().precision(0.1);
+  projection: d3.GeoProjection = PROJECTION_FACTORIES[this.projectionName]().precision(0.1);
 
   // WebGL by default: smooth pan/zoom and a GPU-accelerated globe for large datasets. Canvas2D
   // paints the first frame sooner (no async luma.gl device / GPU tessellation); SVG exports vectors.
@@ -413,7 +421,7 @@ export default class MapStore {
     // Re-fit the new projection to the (fixed) viewport and swap it in place: d3gl re-projects
     // the existing layers and re-dispatches the right interaction (globe rotation vs pan/zoom).
     this.projection = fitProjection(
-      d3[projection]().precision(0.1),
+      PROJECTION_FACTORIES[projection]().precision(0.1),
       sphere as GeoJSON.GeoJSON,
       this.width,
       this.height,

--- a/src/store/SpeciesStore.ts
+++ b/src/store/SpeciesStore.ts
@@ -23,7 +23,7 @@ import { normalizeSpeciesName } from '../utils/names';
 // };
 export interface FeatureProperties {
   name: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export type PointFeature = Feature<Point, FeatureProperties>;
@@ -91,7 +91,7 @@ export default class SpeciesStore {
   timer = new Timer();
   speed: number = 0;
   seconds: number = 0;
-  dataWorker: any = null;
+  dataWorker: Worker | null = null;
 
   constructor(rootStore: RootStore) {
     this.rootStore = rootStore;
@@ -261,7 +261,7 @@ export default class SpeciesStore {
           { type: 'module' }
         );
 
-        dataWorker.addEventListener("message", (event: any) => {
+        dataWorker.addEventListener("message", (event: MessageEvent) => {
           if (event.data.type === "status") {
             if (event.data.status === "complete") {
               dataWorker.terminate();
@@ -306,7 +306,7 @@ export default class SpeciesStore {
           { type: 'module' }
         );
 
-        dataWorker.addEventListener("message", (event: any) => {
+        dataWorker.addEventListener("message", (event: MessageEvent) => {
           if (event.data.type === "status") {
             if (event.data.status === "complete") {
               dataWorker.terminate();
@@ -408,7 +408,7 @@ export default class SpeciesStore {
       nameHistogram[name]++;
     };
 
-    const ignoredRows: any[] = [];
+    const ignoredRows: { [key: string]: string | number }[] = [];
 
     await this.loadData(file, (items) => {
       const multiPoint: MultiPoint = { type: 'MultiPoint', coordinates: [] };
@@ -486,7 +486,12 @@ export default class SpeciesStore {
 
   generateGeojsonFromBins = () => {
     const features = this.binner.cells.map((cell, index) => {
-      const c = Color(cell.color)!;
+      const c = Color(cell.color);
+      if (c == null) {
+        // `d3.color` returns null for an unparseable specifier; a bare `!` here would
+        // have thrown on the property access below, so fail explicitly instead.
+        throw new Error(`Invalid cell color: ${cell.color}`);
+      }
       return {
         type: "Feature",
         geometry: cell.geometry,
@@ -517,7 +522,11 @@ export default class SpeciesStore {
     });
     this.binner.cells.forEach((cell, i) => {
       cell.speciesTopList.forEach(d => {
-        data.get(d.name)![i] = "1";
+        const presenceAbsence = data.get(d.name);
+        if (presenceAbsence === undefined) {
+          throw new Error(`No presence/absence row for species: ${d.name}`);
+        }
+        presenceAbsence[i] = "1";
       })
     })
     return Array.from(data, ([name, value]) => `${name}\t${value.join("")}`).join("\n");
@@ -531,7 +540,11 @@ export default class SpeciesStore {
     });
     this.binner.cells.forEach(cell => {
       cell.speciesTopList.forEach(d => {
-        data.get(d.name)![cell.bioregionId - 1] = "1";
+        const presenceAbsence = data.get(d.name);
+        if (presenceAbsence === undefined) {
+          throw new Error(`No presence/absence row for species: ${d.name}`);
+        }
+        presenceAbsence[cell.bioregionId - 1] = "1";
       })
     })
     return Array.from(data, ([name, value]) => `${name}\t${value.join("")}`).join("\n");
@@ -572,7 +585,7 @@ export default class SpeciesStore {
           commonSpecies: { name: string; count: number; score: number },
           index: number,
         ) => {
-          const indicativeSpecies = mostIndicative[index]!;
+          const indicativeSpecies = mostIndicative[index];
           data.push([
             bioregion.bioregionId,
             index + 1,
@@ -633,7 +646,7 @@ function createMapper<ItemType = string | number>(
 ) {
   return (item: { [key: string]: ItemType }) => ({
     name: `${item[nameColumn]}`,
-    longitude: +item[longColumn]!,
-    latitude: +item[latColumn]!,
+    longitude: +item[longColumn],
+    latitude: +item[latColumn],
   });
 }

--- a/src/store/TreeStore.ts
+++ b/src/store/TreeStore.ts
@@ -204,7 +204,7 @@ export default class TreeStore {
       return {};
     }
     const { colorBioregion } = this.rootStore.colorStore;
-    const styles: { [key: string]: { fillColour: string; shape?: any } } = {};
+    const styles: { [key: string]: { fillColour: string; shape?: string } } = {};
     this.treeNodeMap.forEach((value, name) => {
       if (name && value.bioregionId) {
         styles[name] = {
@@ -258,7 +258,6 @@ export default class TreeStore {
     this.setIsLoading();
     const tree = await loadText(file);
     this.setTreeString(tree);
-    // @ts-ignore
     this.setTree(prepareTree(parseTree(tree)));
     this.setIsLoaded();
   }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -7,7 +7,15 @@ export const StoreContext = createContext(store);
 
 export const useStore = () => useContext(StoreContext);
 
-export const useDemoStore = () =>
-  useContext(StoreContext).documentationStore!.demoStore;
+export const useDemoStore = () => {
+  // `documentationStore` is only created for non-demo RootStores; accessing
+  // `.demoStore` through a bare `!` would throw if it were absent, so guard
+  // explicitly to preserve that "throw on missing" behavior with a clearer message.
+  const { documentationStore } = useContext(StoreContext);
+  if (!documentationStore) {
+    throw new Error('useDemoStore: documentationStore is not available');
+  }
+  return documentationStore.demoStore;
+};
 
 export default store;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,58 +1,57 @@
-import { createSystem, defaultConfig, defineRecipe } from '@chakra-ui/react';
+import {
+  createSystem,
+  defaultConfig,
+  defineRecipe,
+  type SystemStyleObject,
+} from '@chakra-ui/react';
 // import { tableAnatomy as parts } from '@chakra-ui/anatomy';
 // import type {
 //   PartsStyleFunction,
 //   SystemStyleObject,
 // } from '@chakra-ui/theme-tools';
 
-// const numericStyles: SystemStyleObject = {
-const numericStyles: any = {
+const numericStyles: SystemStyleObject = {
   '&[data-is-numeric=true]': {
     textAlign: 'end',
   },
 };
 
-// const tableVariantSimpler: PartsStyleFunction<typeof parts> = () => {
-const tableVariantSimpler: any = () => {
-  const paddingTop = '5px !important';
+const paddingTop = '5px !important';
 
-  return {
-    thead: {
-      th: {
-        textAlign: 'center !important',
-        paddingTop,
-        paddingBottom: paddingTop,
-      },
+const tableVariantSimpler: SystemStyleObject = {
+  '& thead th': {
+    textAlign: 'center !important',
+    paddingTop,
+    paddingBottom: paddingTop,
+  },
+  '& td': {
+    '&:first-of-type': {
+      paddingInlineStart: '0 !important',
+      textAlign: 'start',
     },
-    td: {
-      '&:first-of-type': {
-        paddingInlineStart: '0 !important',
-        textAlign: 'start',
-      },
-      '&:last-of-type': {
-        paddingInlineEnd: '0 !important',
-      },
-      textAlign: 'end',
-      paddingTop,
-      paddingBottom: paddingTop,
+    '&:last-of-type': {
+      paddingInlineEnd: '0 !important',
     },
-    tfoot: {
-      td: {
-        borderColor: 'var(--chakra-colors-gray-100) !important',
-        borderTop: '1px',
-        paddingTop,
-        paddingBottom: paddingTop,
-        ...numericStyles,
-      },
-    },
-  };
+    textAlign: 'end',
+    paddingTop,
+    paddingBottom: paddingTop,
+  },
+  '& tfoot td': {
+    borderColor: 'var(--chakra-colors-gray-100) !important',
+    borderTop: '1px',
+    paddingTop,
+    paddingBottom: paddingTop,
+    ...numericStyles,
+  },
 };
 
 const tableRecipe = defineRecipe({
   variants: {
-    simpler: tableVariantSimpler,
+    simpler: {
+      true: tableVariantSimpler,
+    },
   },
-})
+});
 
 const theme = createSystem(defaultConfig, {
   globalCss: {

--- a/src/types/geojson.d.ts
+++ b/src/types/geojson.d.ts
@@ -156,7 +156,7 @@ export interface GeometryCollection extends GeoJsonObject {
   geometries: Geometry[];
 }
 
-export type GeoJsonProperties = { [name: string]: any } | null;
+export type GeoJsonProperties = { [name: string]: unknown } | null;
 
 /**
  * A feature object which contains a geometry and associated properties.

--- a/src/utils/MaxMap.ts
+++ b/src/utils/MaxMap.ts
@@ -24,7 +24,7 @@ export default class MaxMap<K extends Key> extends Map<K, number> {
 
   set(key: K, value: number): this {
     super.set(key, value);
-    const val = super.get(key)!;
+    const val = value;
     if (val > this.#maxValue) {
       this.#maxKey = key;
       this.#maxValue = val;

--- a/src/utils/QuadTree/Cell.ts
+++ b/src/utils/QuadTree/Cell.ts
@@ -43,7 +43,7 @@ export default class Cell
   private _recalcStats: boolean = true;
   private _speciesTopList: { count: number; name: string }[] = [];
   private _speciesRichness: number = 0;
-  // @ts-ignore
+  // @ts-expect-error narrows ExtendedFeature's `type?: string` to the literal 'Feature'
   type = 'Feature';
 
   constructor(extent: BBox, maxCellSizeLog2: number) {
@@ -416,7 +416,6 @@ export default class Cell
     });
 
     if (doPatch) {
-      // @ts-ignore
       this.features = aggregatedFeatures; // FIXME
     }
 
@@ -505,12 +504,20 @@ export default class Cell
     this.bioregionMetrics.relativeRichness = stddevNumSpeciesWithin < 1e-10 ? 0 : (numSpeciesWithin - meanNumSpeciesWithin) / stddevNumSpeciesWithin;
 
     const endemicity = this.speciesTopList.map(({ name }) => {
-      const species = speciesMap.get(name)!
-      return species.numGridCellsWithinModule! / species.numGridCells!;
+      const species = speciesMap.get(name);
+      if (species === undefined) {
+        throw new Error(`calcBioregionStats: species '${name}' not found in speciesMap`);
+      }
+      // `?? NaN` preserves the prior `!`-then-arithmetic behavior: an unset count
+      // yielded `undefined`, and `undefined / x` is already NaN.
+      return (species.numGridCellsWithinModule ?? NaN) / (species.numGridCells ?? NaN);
     })
     const occupancy = this.speciesTopList.map(({ name }) => {
-      const species = speciesMap.get(name)!
-      return (species.numGridCellsWithinModule! - meanSpeciesExtentWithin) / sddevSpeciesExtentWithin;
+      const species = speciesMap.get(name);
+      if (species === undefined) {
+        throw new Error(`calcBioregionStats: species '${name}' not found in speciesMap`);
+      }
+      return ((species.numGridCellsWithinModule ?? NaN) - meanSpeciesExtentWithin) / sddevSpeciesExtentWithin;
     })
     this.bioregionMetrics.endemicity = calcMedian(endemicity);
     this.bioregionMetrics.occupancy = calcMedian(occupancy);

--- a/src/utils/QuadTree/QuadTreeGeoBinner.ts
+++ b/src/utils/QuadTree/QuadTreeGeoBinner.ts
@@ -329,7 +329,7 @@ export default class QuadtreeGeoBinner {
   //       [d.x2, d.y2],
   //       [d.x1, d.y2],
   //     ]
-  //       // @ts-ignore
+  //       // @ts-expect-error projection accepts a [lon, lat] tuple, not the inferred number[]
   //       .map((point) => projection(point))
   //       .join('L') +
   //     'Z';

--- a/src/utils/loader.ts
+++ b/src/utils/loader.ts
@@ -5,9 +5,9 @@ import Papa, {
   type ParseError,
 } from 'papaparse';
 
-export type ParseAsyncConfig<T = any, TInput = undefined> = ParseLocalConfig<T, TInput> | ParseRemoteConfig<T>;
+export type ParseAsyncConfig<T = unknown, TInput = undefined> = ParseLocalConfig<T, TInput> | ParseRemoteConfig<T>;
 
-function loadLocalFile<T = any>(
+function loadLocalFile<T = unknown>(
   file: File,
   args: ParseLocalConfig<T, File> = { complete: () => { } },
 ) {
@@ -21,11 +21,11 @@ function loadLocalFile<T = any>(
   });
 }
 
-function loadRemoteFile<T = any>(
+function loadRemoteFile<T = unknown>(
   url: string,
   args: Omit<ParseRemoteConfig<T>, 'download'> = { complete: () => { } },
 ) {
-  //@ts-ignore
+  // @ts-expect-error Papa.parse's overloads don't model the (url, config) remote form precisely
   Papa.parse<T, string>(url, {
     download: true,
     dynamicTyping: true,
@@ -39,18 +39,18 @@ function loadRemoteFile<T = any>(
 
 export function loadFile(
   file: string | File,
-  args: ParseAsyncConfig<any, File | string> = { complete: () => { } },
+  args: ParseAsyncConfig<unknown, File | string> = { complete: () => { } },
 ) {
   if (typeof file === 'string') {
-    loadRemoteFile(file, args as ParseRemoteConfig<any>);
+    loadRemoteFile(file, args as ParseRemoteConfig<unknown>);
   } else {
-    loadLocalFile(file, args as ParseLocalConfig<any, File>);
+    loadLocalFile(file, args as ParseLocalConfig<unknown, File>);
   }
 }
 
 export function preview(
   file: string | File,
-  args: ParseAsyncConfig<any, File | string> = { complete: () => { } },
+  args: ParseAsyncConfig<unknown, File | string> = { complete: () => { } },
 ) {
   loadFile(file, {
     preview: 10,
@@ -60,13 +60,13 @@ export function preview(
 
 export function loadPreview(
   file: string | File,
-  args: Omit<ParseAsyncConfig<any, File | string>, 'complete'> = {},
+  args: Omit<ParseAsyncConfig<unknown, File | string>, 'complete'> = {},
 ) {
-  const data: Array<any> = [];
+  const data: Array<unknown> = [];
   const errors: ParseError[] = [];
   let header: string[] = [];
 
-  return new Promise<any>((resolve, reject) => {
+  return new Promise<{ data: unknown[]; header: string[] }>((resolve, reject) => {
     preview(file, {
       complete() {
         if (errors.length > 0) {
@@ -74,7 +74,7 @@ export function loadPreview(
         }
         resolve({ data, header });
       },
-      chunk(chunk: ParseResult<any>) {
+      chunk(chunk: ParseResult<unknown>) {
         if (chunk.meta.fields) {
           header = chunk.meta.fields;
         }

--- a/src/utils/range.ts
+++ b/src/utils/range.ts
@@ -67,7 +67,7 @@ export function rangeArrayOneSignificant(
     }
   }
   if (options.inclusive) {
-    values.push(10 ** stop!);
+    values.push(10 ** stop);
   }
   return values;
 }

--- a/src/utils/svg.ts
+++ b/src/utils/svg.ts
@@ -10,7 +10,7 @@ export function getSVGRenderer(projection: GeoProjection) {
       [d.x2, d.y2],
       [d.x1, d.y2],
     ]
-      // @ts-ignore
+      // @ts-expect-error projection accepts a [lon, lat] tuple, not the inferred number[]
       .map((point) => projection(point))
       .join('L') +
     'Z';

--- a/src/utils/tree/newick.ts
+++ b/src/utils/tree/newick.ts
@@ -60,6 +60,11 @@
 
 const regMatchQuoted = new RegExp(/[['"]*['"]([^']+?)'/g);
 
+// Hoisted reference to Object.prototype.hasOwnProperty so call sites read it via
+// `.call` without accessing the prototype builtin on the target object directly
+// (Object.hasOwn is ES2022; this lib targets ES2020).
+const hasOwn = Object.prototype.hasOwnProperty;
+
 export interface ITree {
   name: string;
   branchLength: number | null;
@@ -149,7 +154,7 @@ function read(newickString: string) {
       default: {
         const x: string = tokens[i - 1];
         if (x === ')' || x === '(' || x === ',') {
-          if (Object.prototype.hasOwnProperty.call(exceptionHashTable, token)) {
+          if (hasOwn.call(exceptionHashTable, token)) {
             const [str1, str2] = exceptionHashTable[token].split(':');
             if (str2) {
               tree.name = str2;
@@ -193,20 +198,20 @@ function write(json: ITree) {
         });
       }
       const substring = newChildren.join();
-      if (Object.prototype.hasOwnProperty.call(nest, 'name')) {
+      if (hasOwn.call(nest, 'name')) {
         subtree = `(${substring})${nest.name}`;
       }
-      if (Object.prototype.hasOwnProperty.call(nest, 'branchLength')) {
+      if (hasOwn.call(nest, 'branchLength')) {
         if (nest.branchLength) {
           subtree = `${subtree}:${nest.branchLength}`;
         }
       }
     } else {
       let leaf: string = '';
-      if (Object.prototype.hasOwnProperty.call(nest, 'name') && nest.name) {
+      if (hasOwn.call(nest, 'name') && nest.name) {
         leaf = nest.name;
       }
-      if (Object.prototype.hasOwnProperty.call(nest, 'branchLength') && nest.branchLength) {
+      if (hasOwn.call(nest, 'branchLength') && nest.branchLength) {
         leaf = `${leaf}:${nest.branchLength}`;
       }
       subtree = subtree + leaf;

--- a/src/utils/tree/parsimony.ts
+++ b/src/utils/tree/parsimony.ts
@@ -38,6 +38,19 @@ export interface AncestralData {
 }
 export type AncestralMap = Map<PhyloNode, AncestralData>;
 
+/**
+ * Read a value that the traversal order guarantees is already present. Throws if it
+ * is missing — same fail-fast behavior a bare `!` would give on the following access,
+ * but with a clearer message.
+ */
+function mustGet<K, V>(map: Map<K, V>, key: K): V {
+  const value = map.get(key);
+  if (value === undefined) {
+    throw new Error('parsimony: expected node entry not found in map');
+  }
+  return value;
+}
+
 const idSet = (s: Region[]): Set<number> => new Set(s.map((r) => r.clusterId));
 /** Regions of `a` also present in `b` (by clusterId), preserving `a`'s order. */
 const intersectBy = (a: Region[], b: Region[]): Region[] => {
@@ -82,7 +95,7 @@ function preliminaryPhase(
       );
       return;
     }
-    const childSets = node.children.map((c) => ranges.get(c)!.clusters);
+    const childSets = node.children.map((c) => mustGet(ranges, c).clusters);
     let anc = childSets.reduce((acc, s) => intersectBy(acc, s));
     const byUnion = anc.length === 0;
     if (byUnion) anc = childSets.reduce((acc, s) => unionBy(acc, s), [] as Region[]);
@@ -95,16 +108,16 @@ function preliminaryPhase(
 function finalPhase(root: PhyloNode, ranges: Map<PhyloNode, RegionSet>): void {
   visitPreOrder(root, (node, parent) => {
     if (!parent || node.isLeaf) return;
-    const prelim = ranges.get(node)!.clusters;
-    const pfinal = ranges.get(parent)!.clusters;
+    const prelim = mustGet(ranges, node).clusters;
+    const pfinal = mustGet(ranges, parent).clusters;
     if (intersectBy(prelim, pfinal).length === pfinal.length) {
       ranges.set(node, set(intersectBy(prelim, pfinal))); // I → II (diminished)
-    } else if (ranges.get(node)!.byUnion) {
+    } else if (mustGet(ranges, node).byUnion) {
       ranges.set(node, set(unionBy(prelim, pfinal))); // III → IV (expanded)
     } else {
       // III → V (encompassing): add parent regions present in ≥1 child's preliminary set.
       const childrenUnion = node.children
-        .map((c) => ranges.get(c)!.clusters)
+        .map((c) => mustGet(ranges, c).clusters)
         .reduce((a, b) => unionBy(a, b), [] as Region[]);
       ranges.set(node, set(unionBy(prelim, intersectBy(pfinal, childrenUnion))));
     }
@@ -177,9 +190,9 @@ export function reconstructAncestralRanges(
   const result: AncestralMap = new Map();
   visitTreeDepthFirstPostOrder(root, (node) => {
     result.set(node, {
-      ranges: ranges.get(node)!,
-      clusters: clusters.get(node)!,
-      speciesCount: speciesCount.get(node)!,
+      ranges: mustGet(ranges, node),
+      clusters: mustGet(clusters, node),
+      speciesCount: mustGet(speciesCount, node),
     });
   });
   return result;

--- a/src/utils/tree/tree.test.ts
+++ b/src/utils/tree/tree.test.ts
@@ -1,5 +1,6 @@
 import { parseTree, prepareTree, visitTreeDepthFirstPostOrder } from '.';
 import type { PhyloNode } from '.';
+import type { ITree } from './newick';
 
 export function testSimpleTree() {
   const tree: PhyloNode = prepareTree({
@@ -43,10 +44,10 @@ export function testSimpleTree() {
 
 export function testNewickTree() {
   const nwk = '(a1,a2,((a311,a312)a31,a32)a3)root;';
-  let tree: any = parseTree(nwk);
+  const parsed: ITree = parseTree(nwk);
 
-  console.log(tree);
-  tree = prepareTree(tree);
+  console.log(parsed);
+  const tree: PhyloNode = prepareTree(parsed);
   console.log(tree);
 
   console.log('Test visit tree');

--- a/src/utils/tree/treeLayout.ts
+++ b/src/utils/tree/treeLayout.ts
@@ -137,8 +137,7 @@ export function makeLinkDraw(
   const [ox, oy] = center;
   if (mode === 'rectangular') {
     const factory = curve === 'linear' ? curveLinear : curve === 'step' ? curveStepBefore : curveBumpX;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const gen: any = (d3link(factory) as any).x((d: LayoutNode) => d.y).y((d: LayoutNode) => d.x);
+    const gen = d3link<LayoutLink, LayoutNode>(factory).x((d) => d.y).y((d) => d.x);
     return (ctx, l) => {
       gen.context(ctx);
       gen(l);
@@ -146,8 +145,7 @@ export function makeLinkDraw(
   }
   if (curve === 'bump') {
     // linkRadial applies the −π/2 internally, so the angle accessor is the raw cluster angle.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const gen: any = (linkRadial() as any).angle((d: LayoutNode) => d.x).radius((d: LayoutNode) => d.y);
+    const gen = linkRadial<LayoutLink, LayoutNode>().angle((d) => d.x).radius((d) => d.y);
     return (ctx, l) => {
       gen.context(offsetCtx(ctx, ox, oy));
       gen(l);

--- a/src/utils/tree/treeUtils.ts
+++ b/src/utils/tree/treeUtils.ts
@@ -1,7 +1,7 @@
 // import { isEqual } from '../math';
 
 //import _ from 'lodash';
-// @ts-ignore
+// @ts-expect-error treeUtilsJS is plain JS without type declarations
 export { prepareTree } from './treeUtilsJS';
 
 export interface Branch {

--- a/src/utils/zoom.ts
+++ b/src/utils/zoom.ts
@@ -81,9 +81,11 @@ export function zoomProjection(
         .call(zoom),
     {
       on(type, ...options) {
-        return options.length
-          ? (zoom.on(type, ...options), this)
-          : zoom.on(type);
+        if (options.length) {
+          zoom.on(type, ...options);
+          return this;
+        }
+        return zoom.on(type);
       },
     },
   );
@@ -113,9 +115,11 @@ export function zoomFixed(
         .call(zoom),
     {
       on(type, ...options) {
-        return options.length
-          ? (zoom.on(type, ...options), this)
-          : zoom.on(type);
+        if (options.length) {
+          zoom.on(type, ...options);
+          return this;
+        }
+        return zoom.on(type);
       },
     },
   );

--- a/src/workers/DataWorker.ts
+++ b/src/workers/DataWorker.ts
@@ -17,7 +17,7 @@ import { normalizeSpeciesName } from '../utils/names';
 
 async function load(
   file: string | File,
-  args: Omit<ParseAsyncConfig<any, File | string>, 'complete'> = {},
+  args: Omit<ParseAsyncConfig<unknown, File | string>, 'complete'> = {},
 ) {
   console.log('Loading...');
 
@@ -29,7 +29,7 @@ async function load(
         postMessage({ type: "status", status: "complete" });
         resolve('Loading finished');
       },
-      chunk(chunk: ParseResult<any>) {
+      chunk(chunk: ParseResult<unknown>) {
         // dataStream.next(chunk.data);
         chunk.errors.forEach(e => {
           console.log(e)
@@ -98,7 +98,7 @@ async function loadShapefiles(files: File[], nameKey?: string) {
   const getNameKey = (() => {
     const keysToTest = ['binomial', 'species', 'name', 'id'] as const;
     let nameKey: string | undefined;
-    return (properties: any) => {
+    return (properties: Record<string, unknown> | null | undefined) => {
       if (nameKey != null) return nameKey;
       const keys = Object.keys(properties ?? {});
       nameKey = keysToTest.find((key) => keys.includes(key));
@@ -162,7 +162,7 @@ async function loadShapefiles(files: File[], nameKey?: string) {
 
       result = await source.read();
     }
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('!! shp error:', error);
   }
 


### PR DESCRIPTION
## Summary
Drives `pnpm lint` (Biome `recommended`) to **0 warnings, 0 errors** by fixing the code — no config exceptions, no `// biome-ignore` suppressions. Follows #75 (which left 152 recommended advisories).

Fixed: 100 `noNonNullAssertion`, 32 `noExplicitAny`, 10 `noTsIgnore`, 5 `noPrototypeBuiltins`, 2 `noDynamicNamespaceImportAccess`, 2 `noCommaOperator`, 1 `noBannedTypes` — across 31 files (commits grouped by layer: InfomapStore, stores, utils/workers, components).

## Approach (behavior preserved throughout — no tests in this repo)
- **`!` (non-null assertions):** removed where TypeScript already narrows (redundant); where genuinely nullable, hoisted to a `const` + an explicit **throwing guard** at the same point a bare `!` would have crashed (preserves fail-on-null, with a clearer message). Get-or-create `map.has?get!:set().get!` idioms rewritten to `const v = map.get(k) ?? new X(); if (!map.has(k)) map.set(k, v)`. Never silently changed a null path; never used `as` casts to dodge the rule.
- **`any`:** replaced with precise types, or `unknown` + narrowing for genuinely dynamic/external values (PapaParse, worker messages, d3 generics).
- **`@ts-ignore` → `@ts-expect-error`** (with reasons); removed where the directive became unused.
- **`d3[name]()`** dynamic access → a static `PROJECTION_FACTORIES` record (identical calls, tree-shakeable). **`hasOwnProperty`** → `Object.prototype.hasOwnProperty.call` (ES2020-safe). **comma operators** (d3 getter/setter) → explicit if/return. **`{}` banned type** → `Record<string, never>`.

## Behavior-sensitive notes (reviewed)
- Many throwing guards replace impossible-path `!`s (Map lookups guaranteed by construction); they throw an explicit error instead of the previous implicit TypeError — same fail-fast, never a silent skip.
- `?? NaN` / `?? 0` used where a `!` followed numeric arithmetic, reproducing the prior `undefined`-arithmetic result exactly.
- `zoom.ts` is `@ts-nocheck` (tsc can't validate); its comma-operator rewrites were verified by hand as equivalent.
- `theme.ts`: a dead `simpler` table-recipe variant (no `variant="simpler"` consumer) was reshaped into a valid Chakra v3 form when its masking `any` was removed — no rendered output changes.

## Test Plan
- [x] `pnpm lint` → 0 warnings, 0 errors (116 files).
- [x] `pnpm exec tsc -b` passes; `pnpm build` succeeds.
- [x] `biome.json` unchanged (plain `recommended`); no suppressions added.
- [ ] Reviewer: sanity-check the throwing guards in `InfomapStore.ts`/`DemoTree.ts`/`parsimony.ts` and the `theme.ts` dead-variant reshape.

Fixes #76
