### PR TITLE
Render top 5 bioregions by default with a show-all toggle

### DIFF
--- a/.changeset/bioregion-list-top-n.md
+++ b/.changeset/bioregion-list-top-n.md
@@ -1,0 +1,8 @@
+---
+"bioregions": patch
+---
+
+Speed up switching hierarchical level on large datasets. The bioregion statistics
+list now renders the top 5 modules by default with a "Show all" toggle, instead of
+mounting a full table and pie charts for every module — which stalled the UI for
+several seconds at deep levels with many modules.

--- a/src/components/Statistics/Bioregions.tsx
+++ b/src/components/Statistics/Bioregions.tsx
@@ -1,4 +1,5 @@
-import { Box, Popover, Table, Text } from '@chakra-ui/react';
+import { Box, Button, Popover, Table, Text } from '@chakra-ui/react';
+import { useState } from 'react';
 import {
   PopoverArrow,
   PopoverBody,
@@ -28,11 +29,42 @@ export default observer(function Bioregions() {
     return null;
   }
 
+  return <BioregionList bioregions={infomapStore.bioregions} />;
+});
+
+// Default number of bioregions to render. Each `BioregionInfo` mounts a Chakra Table plus
+// up to 20 Popover-backed pie charts, so rendering every module at deep hierarchical levels
+// (hundreds of modules) stalls the main thread for many seconds. Cap the default render and
+// let the user opt in to the rest.
+const DEFAULT_VISIBLE = 5;
+
+const BioregionList = observer(function BioregionList({
+  bioregions,
+}: {
+  bioregions: Bioregion[];
+}) {
+  const [showAll, setShowAll] = useState(false);
+
+  // Bioregions are ordered by Infomap flow (largest first), so the head is the top-N.
+  const visible = showAll ? bioregions : bioregions.slice(0, DEFAULT_VISIBLE);
+
   return (
     <>
-      {infomapStore.bioregions.map((bioregion: Bioregion) => (
+      {visible.map((bioregion: Bioregion) => (
         <BioregionInfo bioregion={bioregion} key={bioregion.bioregionId} />
       ))}
+      {bioregions.length > DEFAULT_VISIBLE && (
+        <Button
+          variant="outline"
+          size="sm"
+          alignSelf="center"
+          onClick={() => setShowAll((v) => !v)}
+        >
+          {showAll
+            ? `Show top ${DEFAULT_VISIBLE}`
+            : `Show all ${bioregions.length} bioregions`}
+        </Button>
+      )}
     </>
   );
 });


### PR DESCRIPTION
## What
Switching hierarchical level on large datasets (e.g. **Global mammal occurrences**) stalled the UI for ~10 s at levels 2/3.

## Root cause
The slow path was **not** Infomap, the bioregion rebuild, the tree reconstruction, or the map render — those total ~2 s and are synchronous. The ~10 s was the React re-render of the `Statistics` → `Bioregions` list: it mounts one `BioregionInfo` per module, each containing a Chakra `Table` with up to 10 rows × **2 `Popover`-backed SVG pie charts**. At deep levels (hundreds of modules) that is thousands of portal-backed components committed in a single render. Confirmed by disabling that subtree → the level switch became instant.

## Change
Render only the **top 5** modules by default (already ordered by Infomap flow, largest first) with a **"Show all N bioregions" / "Show top 5"** toggle. The common case is now fast; the full list is one click away.

## Notes
Clicking **"Show all"** on a deep level still mounts everything and can stall — deeper optimization (collapse-on-expand, virtualization, or lazy pie `Popover`s) is tracked separately.

Related to #78.
