### PR TITLE
Responsive map & tree + view-reset controls

### DIFF
--- a/.changeset/responsive-map-tree.md
+++ b/.changeset/responsive-map-tree.md
@@ -1,0 +1,9 @@
+---
+"bioregions": patch
+---
+
+Make the world map and phylogenetic tree responsive: each view now fills the
+available width up to 1200px and keeps a fixed 2:1 aspect ratio, resizing in place
+as the window changes (the map refits its projection, the tree re-lays-out and
+re-culls labels). Updates `@mapequation/d3gl` to 0.6.0 for its responsive
+`aspectRatio` sizing.

--- a/.changeset/view-reset-and-label-spacing.md
+++ b/.changeset/view-reset-and-label-spacing.md
@@ -1,0 +1,8 @@
+---
+"bioregions": patch
+---
+
+Add a reset button to the map and tree status bars that restores the default view
+(pan/zoom, and globe rotation on the map). The tree's button is disabled while the
+view is already at its default. Also widen the tree's right margin so leaf labels
+have more room and are less likely to be clipped.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@fontsource/open-sans": "^5.2.7",
     "@fontsource/philosopher": "^5.2.8",
     "@mapequation/c3": "^1.1.1",
-    "@mapequation/d3gl": "^0.5.0",
+    "@mapequation/d3gl": "^0.6.0",
     "@mapequation/infomap": "2.12.0",
     "@turf/boolean-intersects": "^7.3.5",
     "@turf/turf": "^7.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
       '@mapequation/d3gl':
-        specifier: ^0.5.0
-        version: 0.5.0(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^0.6.0
+        version: 0.6.0(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mapequation/infomap':
         specifier: 2.12.0
         version: 2.12.0(react@19.2.7)
@@ -459,8 +459,8 @@ packages:
   '@mapequation/c3@1.1.1':
     resolution: {integrity: sha512-zIaPZyRZ31rQfCxpBdkbSGieg+37hrCeeMxYgENZe2BlHO+3adpNVFMVAv2eKWs38exA77+SIXEq0Teay4D4vQ==, tarball: https://registry.npmjs.org/@mapequation/c3/-/c3-1.1.1.tgz}
 
-  '@mapequation/d3gl@0.5.0':
-    resolution: {integrity: sha512-dpuhZMxWIlHhaNBQSryIEdELK8ja1yn5uqGwQJdxkXAE1WBOJFBP060d12j+egfR2UY5R4C7mXixWuzIk/ZZMA==, tarball: https://registry.npmjs.org/@mapequation/d3gl/-/d3gl-0.5.0.tgz}
+  '@mapequation/d3gl@0.6.0':
+    resolution: {integrity: sha512-eRAbkxXT8OMG6JT69Gup//3vEMe2H8VtTBuju/MiYi55wBb9RZtLuCrt1O8IC3kh4+3oR8wdnLlloOmD8jpZVw==, tarball: https://registry.npmjs.org/@mapequation/d3gl/-/d3gl-0.6.0.tgz}
     peerDependencies:
       react: ^19
       react-dom: ^19
@@ -2972,7 +2972,7 @@ snapshots:
       d3-color: 3.1.0
       d3-scale-chromatic: 3.1.0
 
-  '@mapequation/d3gl@0.5.0(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@mapequation/d3gl@0.6.0(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@luma.gl/core': 9.3.3
       '@luma.gl/engine': 9.3.3(@luma.gl/core@9.3.3)(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3))

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -10,6 +10,7 @@ import Documentation from './Documentation';
 import ColorMode from './ControlPanel/ColorMode';
 import TreeStatusBar from './StatusBar/TreeStatusBar';
 import { formatThousands } from '../utils/formats';
+import { ASPECT_RATIO, MAX_WIDTH } from '../responsive';
 
 // Tooltip for the hovered tree branch/node: the clade's reconstructed ancestral range,
 // each bioregion sized by its share of the clade's occurrences. The matching bioregions are
@@ -81,15 +82,12 @@ const PhyloTree = observer(function _PhyloTree() {
   }
 
   return (
-    <Box ml={4} position="relative" width={treeStore.width}>
+    <Box ml={4} width="100%" maxW={`${MAX_WIDTH}px`}>
       <TreeStatusBar />
-      {/* Relative wrapper sized to the canvas: the hover tooltip is positioned in the same
-          coordinate space as the d3gl pointer offsets. */}
-      <Box
-        position="relative"
-        width={treeStore.width}
-        height={treeStore.height}
-      >
+      {/* Responsive wrapper: fills the available width (capped at MAX_WIDTH) and keeps a 2:1 box
+          via aspect-ratio. The d3gl host fills it (inset:0) and resizes in place; the hover
+          tooltip lives in the same coordinate space as the d3gl pointer offsets. */}
+      <Box position="relative" width="100%" aspectRatio={ASPECT_RATIO}>
         <div ref={hostRef} style={{ position: 'absolute', inset: 0 }} />
         <TreeTooltip />
       </Box>

--- a/src/components/StatusBar/MapStatusBar.tsx
+++ b/src/components/StatusBar/MapStatusBar.tsx
@@ -11,6 +11,7 @@ import {
   BioregionsIcon,
   BoundariesFuzzyIcon,
   ClipOnIcon,
+  ResetViewIcon,
 } from './icons';
 
 const BACKEND_LABEL: Record<string, string> = { auto: 'GL', canvas: '2D', svg: 'SVG' };
@@ -138,6 +139,15 @@ export default observer(function MapStatusBar() {
           onClick={() => mapStore.setClipToLand(true)}
         >
           <ClipOnIcon r1={r1} r2={r2} ocean={mapStore.waterColor} />
+        </StatusButton>
+      </StatusGroup>
+
+      <StatusGroup caption="view">
+        <StatusButton
+          content="Reset view — pan, zoom & rotation"
+          onClick={() => mapStore.resetView()}
+        >
+          <ResetViewIcon />
         </StatusButton>
       </StatusGroup>
 

--- a/src/components/StatusBar/TreeStatusBar.tsx
+++ b/src/components/StatusBar/TreeStatusBar.tsx
@@ -14,6 +14,7 @@ import {
   LinkBumpIcon,
   CoordsWorldIcon,
   CoordsScreenIcon,
+  ResetViewIcon,
 } from './icons';
 
 const BACKEND_LABEL: Record<string, string> = { auto: 'GL', canvas: '2D', svg: 'SVG' };
@@ -93,6 +94,16 @@ export default observer(function TreeStatusBar() {
             {o.icon}
           </StatusButton>
         ))}
+      </StatusGroup>
+
+      <StatusGroup caption="view">
+        <StatusButton
+          disabled={treeStore.isViewDefault}
+          content="Reset zoom & pan"
+          onClick={() => treeStore.resetView()}
+        >
+          <ResetViewIcon />
+        </StatusButton>
       </StatusGroup>
 
       <StatusBarSettings />

--- a/src/components/StatusBar/icons.tsx
+++ b/src/components/StatusBar/icons.tsx
@@ -250,3 +250,14 @@ export function CoordsScreenIcon() {
     </Stroke>
   );
 }
+
+// --- reset zoom/pan (magnifier with reset corner brackets) ---------------------
+export function ResetViewIcon() {
+  return (
+    <Stroke>
+      <circle cx="10.5" cy="10.5" r="9" />
+      <path d="M17.25 17.25 L22.5 22.5" />
+      <path d="M6.75 9 L6.75 6.75 9 6.75 M12 6.75 L14.25 6.75 14.25 9 M6.75 12 L6.75 14.25 9 14.25 M14.25 12 L14.25 14.25 12 14.25" />
+    </Stroke>
+  );
+}

--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -4,6 +4,7 @@ import { useStore } from '../store/';
 import { Box, Text } from '@chakra-ui/react';
 import { formatThousands } from '../utils/formats';
 import MapStatusBar from './StatusBar/MapStatusBar';
+import { ASPECT_RATIO, MAX_WIDTH } from '../responsive';
 
 // Tooltip for the hovered grid cell: id, size/area, and — once bioregions are computed — a
 // colored bioregion badge and the clade's oldest tree-node time. Driven by d3gl's native
@@ -72,7 +73,6 @@ const MapTooltip = observer(function _MapTooltip() {
 export default observer(function WorldMap() {
   const hostRef = useRef<HTMLDivElement>(null);
   const { mapStore } = useStore();
-  const { width, height } = mapStore;
 
   useEffect(() => {
     if (hostRef.current === null) {
@@ -84,12 +84,13 @@ export default observer(function WorldMap() {
   }, [mapStore]);
 
   return (
-    <Box ml={4} position="relative" width={width}>
+    <Box ml={4} width="100%" maxW={`${MAX_WIDTH}px`}>
       <MapStatusBar />
-      {/* Relative wrapper sized to the canvas: the hover tooltip is positioned in the same
-          coordinate space as the d3gl pointer offsets. Hover outline + selection dimming are
-          handled natively by d3gl on the cells layer (see MapStore.buildLayers). */}
-      <Box position="relative" width={width} height={height}>
+      {/* Responsive wrapper: fills the available width (capped at MAX_WIDTH) and keeps a
+          2:1 box via aspect-ratio. The d3gl host fills it (inset:0) and resizes in place; the
+          hover tooltip lives in the same coordinate space as the d3gl pointer offsets. Hover
+          outline + selection dimming are handled natively by d3gl on the cells layer. */}
+      <Box position="relative" width="100%" aspectRatio={ASPECT_RATIO}>
         <div ref={hostRef} style={{ position: 'absolute', inset: 0 }} />
         <MapTooltip />
       </Box>

--- a/src/responsive.ts
+++ b/src/responsive.ts
@@ -1,0 +1,5 @@
+// Shared responsive-layout constants for the map and tree views. Both render through d3gl's
+// `aspectRatio` sizing mode (d3gl 0.6+): the host fills the available width up to MAX_WIDTH and
+// keeps this width÷height ratio, resizing the engine in place on container changes.
+export const MAX_WIDTH = 1200;
+export const ASPECT_RATIO = 2;

--- a/src/store/MapStore.ts
+++ b/src/store/MapStore.ts
@@ -11,6 +11,7 @@ import {
   type HoverHit,
 } from '@mapequation/d3gl/map';
 import { fitProjection } from '@mapequation/d3gl/geo';
+import { ASPECT_RATIO, MAX_WIDTH } from '../responsive';
 
 export const BACKENDS: BackendType[] = ['auto', 'canvas', 'svg'];
 
@@ -99,8 +100,12 @@ export default class MapStore {
   // re-read and re-project everything (time-sliced by d3gl) — append only covers the new delta.
   private pointsHandle: LayerHandle<MultiPoint> | null = null;
 
-  width: number = 1200;
-  height: number = 900;
+  // Current CSS pixel size, mirrored from the responsive host so projection re-fits
+  // (setProjection) use the live box. The host is the single source of truth (d3gl owns
+  // resize); these are kept in sync by `sizeObserver`.
+  width: number = MAX_WIDTH;
+  height: number = MAX_WIDTH / ASPECT_RATIO;
+  private sizeObserver: ResizeObserver | null = null;
 
   renderType: RenderType = 'records';
   clipToLand: boolean = true;
@@ -147,6 +152,7 @@ export default class MapStore {
       backend: observable,
       setBackend: action,
       setProjection: action,
+      resetView: action,
       setRenderType: action,
     });
   }
@@ -278,23 +284,50 @@ export default class MapStore {
   }
 
   disposeEngine = () => {
+    this.sizeObserver?.disconnect();
+    this.sizeObserver = null;
     this.pointsHandle = null;
     this.engine?.destroy();
     this.engine = null;
   };
 
+  // Mirror the responsive host's CSS width into this.width/height (height = width / aspect).
+  // d3gl runs its own ResizeObserver to resize+refit the engine; this one only keeps the
+  // store's size in sync so setProjection re-fits to the current box. Sharing the host means
+  // both observers see the same value.
+  private observeSize() {
+    const host = this.host;
+    if (host === null) return;
+    const measure = () => {
+      const w = Math.round(host.getBoundingClientRect().width);
+      if (w > 0) {
+        this.width = w;
+        this.height = Math.round(w / ASPECT_RATIO);
+      }
+    };
+    measure();
+    if (typeof ResizeObserver !== 'undefined') {
+      this.sizeObserver = new ResizeObserver(measure);
+      this.sizeObserver.observe(host);
+    }
+  }
+
   private initEngine() {
     if (this.host === null) return;
     this.disposeEngine();
 
-    this.adjustHeight();
-    // Size the host element to match the engine (height depends on the projection fit).
-    this.host.style.width = `${this.width}px`;
-    this.host.style.height = `${this.height}px`;
+    this.observeSize();
+    // Fit the projection to the measured box so the first paint is correct; the engine refits
+    // on every later resize via its own ResizeObserver (GeoMap.onResize).
+    this.projection = fitProjection(
+      PROJECTION_FACTORIES[this.projectionName]().precision(0.1),
+      sphere as GeoJSON.GeoJSON,
+      this.width,
+      this.height,
+    );
 
     const engine = geoMap(this.host, {
-      width: this.width,
-      height: this.height,
+      aspectRatio: ASPECT_RATIO,
       projection: this.projection,
       backend: this.backend,
     });
@@ -429,16 +462,11 @@ export default class MapStore {
     this.engine?.setProjection(this.projection);
   }
 
-  adjustHeight() {
-    const { projection, width } = this;
-    const [[x0, y0], [x1, y1]] = d3
-      .geoPath(projection.fitWidth(width, sphere))
-      .bounds(sphere);
-    const height = Math.ceil(y1 - y0);
-    const l = Math.min(Math.ceil(x1 - x0), height);
-    projection.scale((projection.scale() * (l - 1)) / l).precision(0.2);
-    this.height = height;
-    projection.translate([width / 2, height / 2]);
+  // Reset pan/zoom (flat) or rotation (globe) to the default view. Re-fitting the current
+  // projection re-projects the layers, resets the affine transform to identity, and re-seeds
+  // the interaction — the same path setProjection takes, with the projection unchanged.
+  resetView() {
+    this.setProjection(this.projectionName);
   }
 
   // --- Hover tooltip + cross-highlight (native d3gl interaction) ---

--- a/src/store/TreeStore.ts
+++ b/src/store/TreeStore.ts
@@ -42,15 +42,18 @@ import {
 } from '@mapequation/d3gl/map';
 import { LabelLayer, type LabelAnchor } from '@mapequation/d3gl/labels';
 import type { ViewTransform } from '@mapequation/d3gl/geo';
+import { ASPECT_RATIO, MAX_WIDTH } from '../responsive';
 
 export type TreeNode = {
   data: PhyloNode;
   bioregionId?: number;
 };
 
-// Tree viewport (the d3gl plot is laid out in these world coordinates).
-const TREE_WIDTH = 760;
-const TREE_HEIGHT = 520;
+// Tree viewport (the d3gl plot is laid out in these world coordinates). Responsive: the plot
+// fills the available width up to MAX_WIDTH at ASPECT_RATIO; the layout is recomputed for the
+// live box on resize (the render autorun tracks width/height).
+const TREE_WIDTH = MAX_WIDTH;
+const TREE_HEIGHT = MAX_WIDTH / ASPECT_RATIO;
 const LINE_MIN = 0.6;
 const LINE_MAX = 9; // branch-width range when scaling by subtended terminals
 const PIE_MIN = 3;
@@ -97,6 +100,8 @@ export default class TreeStore {
   weightParameter: number = 0.5; // Domain [0,1] for tree weight
   treeNodeMap = new Map<string, TreeNode>(); // name -> { data: PhyloNode, bioregionId: number }
 
+  // World-coordinate viewport, mirrored from the responsive host. Observable so the render
+  // autorun re-lays-out the tree (and re-culls labels) when the container resizes.
   width = TREE_WIDTH;
   height = TREE_HEIGHT;
   // Canvas2D default for an instant first frame; WebGL is smoother for very large trees.
@@ -111,8 +116,9 @@ export default class TreeStore {
   private labelEl: HTMLDivElement | null = null;
   private labels: LabelLayer | null = null;
   private anchors: LabelAnchor[] = [];
-  private view: ViewTransform = { k: 1, x: 0, y: 0 };
+  view: ViewTransform = { k: 1, x: 0, y: 0 };
   private renderDisposer: IReactionDisposer | null = null;
+  private sizeObserver: ResizeObserver | null = null;
 
   // Latest ancestral-range reconstruction (node → ranges/distribution), looked up on hover.
   // Kept off the observable graph: it's rebuilt by `renderTree` and read by `onHover`.
@@ -135,6 +141,13 @@ export default class TreeStore {
       treeString: observable,
       weightParameter: observable,
       numLeafNodes: observable,
+      width: observable,
+      height: observable,
+      setSize: action,
+      view: observable.ref,
+      setView: action,
+      resetView: action,
+      isViewDefault: computed,
       backend: observable,
       setBackend: action,
       layout: observable,
@@ -313,12 +326,59 @@ export default class TreeStore {
     return result;
   }
 
+  setSize = action((width: number, height: number) => {
+    this.width = width;
+    this.height = height;
+  });
+
+  // Mirror the responsive host's CSS width into width/height (height = width / aspect). Unlike
+  // GeoMap, a Plot keeps fixed world coords on resize (no auto-refit), so the render autorun
+  // re-lays-out the tree to the new box when these observables change. d3gl runs its own
+  // ResizeObserver on the same host to resize the canvas surface.
+  private observeSize(host: HTMLElement) {
+    const measure = () => {
+      const w = Math.round(host.getBoundingClientRect().width);
+      if (w > 0) this.setSize(w, Math.round(w / ASPECT_RATIO));
+    };
+    measure();
+    if (typeof ResizeObserver !== 'undefined') {
+      this.sizeObserver = new ResizeObserver(measure);
+      this.sizeObserver.observe(host);
+    }
+  }
+
+  setView = action((t: ViewTransform) => {
+    this.view = t;
+  });
+
+  /** True when the view is at its default (no pan/zoom) — drives the reset button's disabled state. */
+  get isViewDefault() {
+    const { k, x, y } = this.view;
+    return k === 1 && x === 0 && y === 0;
+  }
+
+  /** Wire d3-zoom; also re-seeds its internal transform from the current `view`, so calling this
+   *  after a programmatic setTransform keeps the gesture state in sync. */
+  private enableTreeZoom() {
+    this.engine?.enableZoom([0.5, 40], (t) => {
+      this.setView(t);
+      this.updateLabels();
+    });
+  }
+
+  /** Reset zoom/pan to identity and re-align d3-zoom + the label overlay. */
+  resetView = action(() => {
+    this.setView({ k: 1, x: 0, y: 0 });
+    this.engine?.setTransform(this.view);
+    this.enableTreeZoom();
+    this.updateLabels();
+  });
+
   setHost(host: HTMLElement) {
     this.disposeEngine();
 
     const engine = plot(host, {
-      width: this.width,
-      height: this.height,
+      aspectRatio: ASPECT_RATIO,
       backend: this.backend,
     });
     this.engine = engine;
@@ -335,21 +395,23 @@ export default class TreeStore {
     this.labelEl = labelEl;
     this.labels = new LabelLayer(labelEl, (a) => a.text);
 
-    engine.enableZoom([0.5, 40], (t) => {
-      this.view = t;
-      this.updateLabels();
-    });
+    this.enableTreeZoom();
 
     // Native d3gl picking (clip-aware): hovering a branch or node pie reads out that clade's
     // reconstructed ancestral range — shown in the tree tooltip and cross-highlighted on the map.
     engine.on('hover', this.onHover);
 
-    // Rebuild whenever the tree, bioregions, or colors change (autorun tracks the reads).
+    // Set the initial size from the laid-out host before the first render, then track resizes.
+    this.observeSize(host);
+
+    // Rebuild whenever the tree, bioregions, colors, or size change (autorun tracks the reads).
     this.renderDisposer = autorun(() => this.renderTree());
   }
 
   disposeEngine = () => {
     this.clearHover();
+    this.sizeObserver?.disconnect();
+    this.sizeObserver = null;
     this.renderDisposer?.();
     this.renderDisposer = null;
     this.labels?.destroy();

--- a/src/utils/tree/treeLayout.ts
+++ b/src/utils/tree/treeLayout.ts
@@ -36,11 +36,14 @@ function layoutRectangular(
   width: number,
   height: number,
   pad = 40,
+  // Wider right margin than the other edges: leaf labels are drawn outward of the youngest
+  // tips (time = 1), so the tips stop short of the right edge to leave room for the names.
+  padRight = 150,
 ): LayoutNode {
   const h = cluster<PhyloNode>().size([height - 2 * pad, 1])(
     hierarchy(root, (d) => d.children),
   );
-  const time = scaleLinear().domain([0, 1]).range([pad, width - pad]);
+  const time = scaleLinear().domain([0, 1]).range([pad, width - padRight]);
   h.each((n) => {
     n.x += pad;
     n.y = time(n.data.time);


### PR DESCRIPTION
## Summary

- **Responsive views** — the world map and phylogenetic tree now fill the available width up to **1200px** at a fixed **2:1 aspect ratio**, resizing in place as the window changes. The map refits its projection on resize; the tree re-lays-out and re-culls labels. Bumps `@mapequation/d3gl` to **0.6.0** for its responsive `aspectRatio` sizing mode.
- **Reset view controls** — a reset button on both status bars restores the default view (pan/zoom, plus globe rotation on the map). The tree's button is disabled while already at the default (its view transform is tracked); the map's is always enabled (globe rotation state lives inside d3gl, so "at default" isn't trivially detectable).
- **Tree label spacing** — wider right margin so leaf labels have more room and are less likely to be clipped.

## Notes

- Shared responsive constants live in `src/responsive.ts` to avoid coupling `MapStore` and `TreeStore`.
- The reset icon is the standard zoom-reset magnifier, built through the shared `Stroke` icon helper for visual consistency.

## Verification

- `tsc -b` and `biome lint src/` pass clean.
- Dev server boots and serves without new console errors (the pre-existing duplicate-React-key warnings on example data are unrelated to this change).