### PR TITLE
ci: exclude @mapequation packages from the minimum-release-age gate

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+# Exclude first-party @mapequation packages from the `minimumReleaseAge` supply-chain
+# gate. The environment (local dev + CI) rejects lockfile entries newer than a 24h
+# cutoff; our own freshly-published packages (e.g. @mapequation/d3gl) are trusted, so
+# allow them through without waiting. pnpm reads this setting from pnpm-workspace.yaml.
+minimumReleaseAgeExclude:
+  - '@mapequation/*'


### PR DESCRIPTION
## Problem

The Release and GitHub Pages deploy workflows failed on the previous merge: CI's `pnpm install --frozen-lockfile` enforces a 24h `minimumReleaseAge` supply-chain gate, and `@mapequation/d3gl@0.6.0` (published 2026-06-16 23:06 UTC) was still inside that window:

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION]
  @mapequation/d3gl@0.6.0 was published ... within the minimumReleaseAge cutoff
```

## Fix

Add `minimumReleaseAgeExclude: ['@mapequation/*']` in `pnpm-workspace.yaml` (the file pnpm reads this setting from) so CI trusts our own first-party packages without waiting out the freshness window. Verified locally that `pnpm install --frozen-lockfile` passes with this file and no global config present.