### PR TITLE
Update d3gl to 0.7.0 and adopt oriented radial-tree labels

### DIFF
--- a/.changeset/d3gl-0-7-oriented-labels.md
+++ b/.changeset/d3gl-0-7-oriented-labels.md
@@ -1,0 +1,11 @@
+---
+"bioregions": patch
+---
+
+Update `@mapequation/d3gl` to 0.7.0 and adopt its oriented-label model for the
+radial tree. Leaf labels now declare their reading angle (`rotation`/`textAnchor`/
+`keepUpright`) instead of a hand-written CSS transform, so d3gl collides them by
+their true rotated footprint — rotated tips pack tighter and fill the radial fan
+instead of leaving gaps toward the top. The radial branch drawing also drops the
+old `offsetCtx` shim in favour of d3gl's `ctx.translate`. The 0.7.0 bump
+additionally brings faster screen-space declutter for large node counts.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@fontsource/open-sans": "^5.2.7",
     "@fontsource/philosopher": "^5.2.8",
     "@mapequation/c3": "^1.1.1",
-    "@mapequation/d3gl": "^0.6.0",
+    "@mapequation/d3gl": "^0.7.0",
     "@mapequation/infomap": "2.12.0",
     "@turf/boolean-intersects": "^7.3.5",
     "@turf/turf": "^7.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
       '@mapequation/d3gl':
-        specifier: ^0.6.0
-        version: 0.6.0(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^0.7.0
+        version: 0.7.0(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mapequation/infomap':
         specifier: 2.12.0
         version: 2.12.0(react@19.2.7)
@@ -459,8 +459,8 @@ packages:
   '@mapequation/c3@1.1.1':
     resolution: {integrity: sha512-zIaPZyRZ31rQfCxpBdkbSGieg+37hrCeeMxYgENZe2BlHO+3adpNVFMVAv2eKWs38exA77+SIXEq0Teay4D4vQ==, tarball: https://registry.npmjs.org/@mapequation/c3/-/c3-1.1.1.tgz}
 
-  '@mapequation/d3gl@0.6.0':
-    resolution: {integrity: sha512-eRAbkxXT8OMG6JT69Gup//3vEMe2H8VtTBuju/MiYi55wBb9RZtLuCrt1O8IC3kh4+3oR8wdnLlloOmD8jpZVw==, tarball: https://registry.npmjs.org/@mapequation/d3gl/-/d3gl-0.6.0.tgz}
+  '@mapequation/d3gl@0.7.0':
+    resolution: {integrity: sha512-/zX14urvLe8DeA8PZ4EAbfOdwO4hYMcy77eym76kSW1Jada5e0YtzSF1dEiflTDVN7oYLhT8A0C9YnG4qno7ug==, tarball: https://registry.npmjs.org/@mapequation/d3gl/-/d3gl-0.7.0.tgz}
     peerDependencies:
       react: ^19
       react-dom: ^19
@@ -2369,6 +2369,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==, tarball: https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -2972,7 +2973,7 @@ snapshots:
       d3-color: 3.1.0
       d3-scale-chromatic: 3.1.0
 
-  '@mapequation/d3gl@0.6.0(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@mapequation/d3gl@0.7.0(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@luma.gl/core': 9.3.3
       '@luma.gl/engine': 9.3.3(@luma.gl/core@9.3.3)(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3))

--- a/src/store/TreeStore.ts
+++ b/src/store/TreeStore.ts
@@ -21,7 +21,6 @@ import {
   layoutTree,
   nodeXY,
   makeLinkDraw,
-  labelTransform,
   labelOffset,
   type LayoutNode,
   type LayoutLink,
@@ -573,10 +572,11 @@ export default class TreeStore {
     }
 
     // Leaf labels (outward of each tip).
+    const radial = mode === 'radial';
     this.anchors = leaves.map((n, i) => {
       const [px, py] = xy(n);
       const name = n.data.name;
-      const a = n.x - Math.PI / 2; // screen-direction angle for radial placement
+      const a = n.x - Math.PI / 2; // reading-direction angle for radial placement
       return {
         id: `t${i}`,
         refX: px,
@@ -586,8 +586,14 @@ export default class TreeStore {
         height: LABEL_H,
         priority: dataOf(n)?.speciesCount ?? 1,
         offset: labelOffset(mode, a, LABEL_GAP, LABEL_H),
-        transform: labelTransform(mode, a),
-        transformOrigin: '0 0',
+        // Radial: declare the reading angle and let d3gl derive BOTH the CSS transform and the
+        // oriented collision box from it (with the upright flip), so rotated tips pack by their
+        // true on-screen footprint and fill the fan — instead of the old hand-written transform,
+        // which left d3gl colliding them as wide axis-aligned boxes and over-excluding neighbours
+        // toward the top of the tree. Rectangular labels stay plain axis-aligned (no transform).
+        ...(radial
+          ? { rotation: a, textAnchor: 'start' as const, keepUpright: true }
+          : {}),
       } as LabelAnchor;
     });
 

--- a/src/utils/tree/treeLayout.ts
+++ b/src/utils/tree/treeLayout.ts
@@ -108,29 +108,12 @@ export function nodeXY(
 }
 
 /**
- * Wrap a canvas-like context so every path call is shifted by (ox, oy). Used for the radial
- * `linkRadial` generator, which emits coordinates around the origin (the d3gl path context has
- * no `translate()`). Ported from the d3gl ancestral-ranges example.
- */
-function offsetCtx(ctx: CanvasRenderingContext2D, ox: number, oy: number): CanvasRenderingContext2D {
-  return {
-    beginPath: () => ctx.beginPath(),
-    closePath: () => ctx.closePath(),
-    moveTo: (x: number, y: number) => ctx.moveTo(x + ox, y + oy),
-    lineTo: (x: number, y: number) => ctx.lineTo(x + ox, y + oy),
-    quadraticCurveTo: (cx: number, cy: number, x: number, y: number) =>
-      ctx.quadraticCurveTo(cx + ox, cy + oy, x + ox, y + oy),
-    bezierCurveTo: (c1x: number, c1y: number, c2x: number, c2y: number, x: number, y: number) =>
-      ctx.bezierCurveTo(c1x + ox, c1y + oy, c2x + ox, c2y + oy, x + ox, y + oy),
-    arc: (x: number, y: number, r: number, a0: number, a1: number, ccw?: boolean) =>
-      ctx.arc(x + ox, y + oy, r, a0, a1, ccw),
-  } as unknown as CanvasRenderingContext2D;
-}
-
-/**
  * A link-drawing closure for the chosen layout + curve, ported from the d3gl ancestral-ranges
- * example. Radial layouts are origin-centred by d3-shape; `center` ([ox, oy]) is baked into the
- * emitted coordinates so the figure is centred at the identity transform.
+ * example. Radial layouts are origin-centred by d3-shape's `pointRadial`/`linkRadial`; each
+ * radial closure does `ctx.translate(ox, oy)` once (d3gl's path context supports the canonical
+ * canvas translate) to land the fan at the canvas centre `center` ([ox, oy]). The view transform
+ * stays at identity, so the user's zoom survives layout/curve toggles. Rectangular needs no
+ * offset (center is [0, 0]).
  */
 export function makeLinkDraw(
   mode: LayoutMode,
@@ -150,41 +133,32 @@ export function makeLinkDraw(
     // linkRadial applies the −π/2 internally, so the angle accessor is the raw cluster angle.
     const gen = linkRadial<LayoutLink, LayoutNode>().angle((d) => d.x).radius((d) => d.y);
     return (ctx, l) => {
-      gen.context(offsetCtx(ctx, ox, oy));
+      ctx.translate(ox, oy);
+      gen.context(ctx);
       gen(l);
     };
   }
   if (curve === 'linear') {
     return (ctx, l) => {
+      ctx.translate(ox, oy);
       const [sx, sy] = pointRadial(l.source.x, l.source.y);
       const [tx, ty] = pointRadial(l.target.x, l.target.y);
-      ctx.moveTo(sx + ox, sy + oy);
-      ctx.lineTo(tx + ox, ty + oy);
+      ctx.moveTo(sx, sy);
+      ctx.lineTo(tx, ty);
     };
   }
   // radial "step": arc along the parent radius to the child angle, then a radial line out.
   // The arc angles use −π/2 to match pointRadial's orientation.
   return (ctx, l) => {
+    ctx.translate(ox, oy);
     const r0 = l.source.y;
     const sa = l.source.x - Math.PI / 2;
     const ta = l.target.x - Math.PI / 2;
-    ctx.moveTo(r0 * Math.cos(sa) + ox, r0 * Math.sin(sa) + oy);
-    ctx.arc(ox, oy, r0, sa, ta, ta < sa);
+    ctx.moveTo(r0 * Math.cos(sa), r0 * Math.sin(sa));
+    ctx.arc(0, 0, r0, sa, ta, ta < sa);
     const [tx, ty] = pointRadial(l.target.x, l.target.y);
-    ctx.lineTo(tx + ox, ty + oy);
+    ctx.lineTo(tx, ty);
   };
-}
-
-/**
- * Rotation/centering CSS transform for a radial leaf label. `a` is the node's screen-direction
- * angle (the cluster angle minus π/2, matching `pointRadial`). Empty for rectangular.
- */
-export function labelTransform(mode: LayoutMode, a: number): string {
-  if (mode !== 'radial') return '';
-  const deg = (a * 180) / Math.PI;
-  return Math.cos(a) < 0
-    ? `rotate(${deg + 180}deg) translate(-100%, -50%)`
-    : `rotate(${deg}deg) translate(0, -50%)`;
 }
 
 /**


### PR DESCRIPTION
## What

Bump `@mapequation/d3gl` `^0.6.0` → `^0.7.0` and adopt its oriented-label model for the radial phylogenetic tree.

## Why

d3gl 0.7.0 ships two relevant improvements; this PR wires the app up to use them:

- **Rotated-label declutter (d3gl #59)** — needed an app change. `TreeStore` was hand-writing `transform`/`transformOrigin` on each leaf label, which kept d3gl on the old axis-aligned collision path: near-vertical radial labels reserved a wide horizontal box and over-excluded their angular neighbours, leaving gaps toward the top of the fan. Radial anchors now declare `rotation` + `textAnchor: 'start'` + `keepUpright`, so d3gl derives both the CSS transform and the oriented collision box from one angle and labels pack by their true on-screen footprint, filling the fan.
- **Screen-space declutter perf (d3gl #94)** — internal to the engine (per-layer anchor-grouping cache + reused grid). The only consumer knob is `declutter?: number`, which `TreeStore` already passes, so the bump delivers it with no app change.

Also drops the `offsetCtx` shim from the radial branch drawing in favour of d3gl's `ctx.translate` (the PathContext translate seam added in d3gl #90), and removes the now-unused `labelTransform` helper.

## Changes

- `package.json` / `pnpm-lock.yaml` — `@mapequation/d3gl` → `^0.7.0`
- `src/store/TreeStore.ts` — radial labels use the oriented model; drop `labelTransform` import
- `src/utils/tree/treeLayout.ts` — remove `offsetCtx` (use `ctx.translate`) and the dead `labelTransform`
- `.changeset/d3gl-0-7-oriented-labels.md`

## Verification

- `tsc -b` passes clean; no `offsetCtx` / `labelTransform` references remain.
- Not run: no runtime render check (no test runner configured). Recommend an eyes-on pass on the radial tree at a high tip count to confirm the fan fills and left-side labels stay upright.

## Follow-up

Declutter speed on screen-mode nodes to be investigated separately (the perf path is now present in the library; confirming the app benefits in practice is deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCCtgSXiZHZmGjFLtkLnd1