### PR TITLE
Fix sluggish zoom/pan on ancestral-ranges tree

### DIFF
--- a/.changeset/tree-zoom-perf.md
+++ b/.changeset/tree-zoom-perf.md
@@ -1,0 +1,9 @@
+---
+"bioregions": patch
+---
+
+Fix sluggish zoom/pan on the ancestral-ranges tree. The render autorun was
+transitively subscribing to the zoom transform (via `updateLabels` reading the
+observable `view`), so every pan/zoom tick re-ran the full tree layout and
+ancestral-range reconstruction. Labels are now repositioned with the live
+transform and the `view` read is untracked, so a gesture only re-places labels.

--- a/src/store/TreeStore.ts
+++ b/src/store/TreeStore.ts
@@ -4,6 +4,7 @@ import {
   action,
   computed,
   autorun,
+  untracked,
   type IReactionDisposer,
 } from 'mobx';
 import type RootStore from './RootStore';
@@ -360,8 +361,11 @@ export default class TreeStore {
    *  after a programmatic setTransform keeps the gesture state in sync. */
   private enableTreeZoom() {
     this.engine?.enableZoom([0.5, 40], (t) => {
+      // Keep `view` in sync for the reset button (cheap: the render autorun no longer
+      // subscribes to it — see updateLabels). Reposition labels with the live transform,
+      // mirroring the d3gl ancestral-ranges example, instead of going through the observable.
       this.setView(t);
-      this.updateLabels();
+      this.updateLabels(t);
     });
   }
 
@@ -423,8 +427,12 @@ export default class TreeStore {
     this.engine = null;
   };
 
-  private updateLabels() {
-    this.labels?.update(this.anchors, this.view, {
+  // `view` is read untracked so the render autorun (which calls this at the end of renderTree)
+  // does NOT subscribe to the zoom transform — otherwise every pan/zoom tick would invalidate
+  // the autorun and re-run the full layout + ancestral reconstruction. The zoom callback passes
+  // the live transform `t` directly for real-time label placement.
+  private updateLabels(view: ViewTransform = untracked(() => this.view)) {
+    this.labels?.update(this.anchors, view, {
       width: this.width,
       height: this.height,
     });
@@ -460,8 +468,8 @@ export default class TreeStore {
     if (tree === null) {
       this.clearHover();
       this.ancestral = null;
-      engine.layer('links', [], { draw: () => {} });
-      engine.layer('pies', [], { draw: () => {} });
+      engine.layer('links', [], { draw: () => { } });
+      engine.layer('pies', [], { draw: () => { } });
       this.anchors = [];
       this.updateLabels();
       engine.render();
@@ -568,7 +576,7 @@ export default class TreeStore {
       // No bioregions yet: no ancestral ranges to hover, so drop any stale reconstruction/hover.
       this.ancestral = null;
       this.clearHover();
-      engine.layer('pies', [], { draw: () => {} });
+      engine.layer('pies', [], { draw: () => { } });
     }
 
     // Leaf labels (outward of each tip).


### PR DESCRIPTION
## Problem

Zoom/pan on the ancestral-ranges tree was sluggish. The render autorun
(`autorun(() => this.renderTree())`) was *transitively* subscribing to the zoom
transform: `renderTree()` ends with `this.updateLabels()`, which read the
observable `view`. So every pan/zoom tick invalidated the autorun and re-ran the
full pipeline — `layoutTree()`, `reconstructAncestralRanges()` (Fitch over the
whole tree), a full `links`/`pies`/`anchors` rebuild, and `engine.render()` — once
per frame.

The d3gl `ancestral-ranges` example is smooth because its `view` is a plain local
variable, so its render path never subscribes to the transform.

## Fix

- Read `view` **untracked** inside `updateLabels`, so the render autorun no longer
  subscribes to the zoom transform. This is the actual perf fix.
- Pass the live transform `t` straight to `updateLabels` from the zoom callback
  (mirroring the d3gl example) for real-time label placement.
- Keep `setView(t)` so the reset button's `isViewDefault` stays correct — now cheap,
  since nothing expensive subscribes to `view` anymore.

Net: per-frame work during a gesture is just `labels.update(...)`.

## Verification

- `pnpm exec tsc -b` passes.
- Manual: labels track the zoom/pan in real time; reset button enables/disables and
  resets correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)